### PR TITLE
Add no-repo-update option and remove CP_HOME_DIR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ The script leaves the CocoaPods specs repositories in their default location; on
 ```
 
 These examples may be adapted to match your project paths. Repositories are written to `DEST/<final-dir-name>` (default `DEST/repos/`).
+
+## Listing external dependencies
+
+Use `Scripts/list_external_deps.sh` to print pods that come from external sources (e.g., git repositories) listed in a `Podfile.lock`:
+
+```bash
+./Scripts/list_external_deps.sh /path/to/Podfile.lock
+```
+
+Each line outputs the pod name, the source URL, and the tag/commit when available. Pods fetched from the central specs repo are ignored.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,72 @@ cd cocoapods_capture_v25
 # In-place patch attempt (auto-detect; falls back to RUBYOPT if not found)
 ./Scripts/fetch_pods.sh --patch-downloader-git --podfile-dir ./Sample --dest ./output --verbose
 ```
-Cloned repos end up in `DEST/repos/`. Add `CP_GIT_SHALLOW=0` to disable shallow clones.
+Cloned repos end up in `DEST/repos/`. Pass `--unshallow` to fetch full Git histories instead of the default shallow clones.
 
-### Additional options
+## Options
 
-- `--no-repo-update` &ndash; forwards the flag to `pod install` so CocoaPods skips updating the specs repos.
+The script accepts the following flags (they may be combined unless noted):
+
+| Flag | Description |
+| --- | --- |
+| `--podfile-dir DIR` | Directory containing the `Podfile` to install (defaults to `Sample`). |
+| `--dest DIR` | Output directory where capture results are written (defaults to `output`). |
+| `--verbose` | Runs `pod install` in verbose mode. |
+| `--unshallow` | Fetches full Git histories (`CP_GIT_SHALLOW=0`). |
+| `--patch-downloader-git` | Attempts in-place patching of CocoaPods' `downloader/git.rb`; falls back to RUBYOPT on failure. |
+| `--restore-downloader-git` | Restores `downloader/git.rb` to its original state and exits. |
+| `--no-repo-update` | Passes the same flag to `pod install` to skip updating the specs repos. |
+| `--keep-all` | Retains Pods, logs, and temporary directories instead of cleaning up. |
+| `--final-dir-name NAME` | Changes the directory name under `DEST` where repositories are finalized (defaults to `repos`). |
 
 The script leaves the CocoaPods specs repositories in their default location; only the library clone directories are captured via the patched `git.rb`.
+
+## Example command combinations
+
+**Basic non-invasive capture**
+```bash
+./Scripts/fetch_pods.sh --podfile-dir ./Sample --dest ./output
+```
+
+**Non-invasive with verbose output and skipping spec repo updates**
+```bash
+./Scripts/fetch_pods.sh \
+  --podfile-dir ./Sample \
+  --dest ./output \
+  --verbose \
+  --no-repo-update
+```
+
+**Fetch full histories and keep all generated files**
+```bash
+./Scripts/fetch_pods.sh \
+  --podfile-dir ./Sample \
+  --dest ./output \
+  --unshallow \
+  --keep-all
+```
+
+**In-place downloader patch**
+```bash
+./Scripts/fetch_pods.sh \
+  --patch-downloader-git \
+  --podfile-dir ./Sample \
+  --dest ./output
+```
+
+**In-place patch with no repo update and custom output folder**
+```bash
+./Scripts/fetch_pods.sh \
+  --patch-downloader-git \
+  --podfile-dir ./Sample \
+  --dest ./capture \
+  --no-repo-update \
+  --final-dir-name libs
+```
+
+**Restore CocoaPods' downloader after patching**
+```bash
+./Scripts/fetch_pods.sh --restore-downloader-git
+```
+
+These examples may be adapted to match your project paths. Repositories are written to `DEST/<final-dir-name>` (default `DEST/repos/`).

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ cd cocoapods_capture_v25
 ./Scripts/fetch_pods.sh --patch-downloader-git --podfile-dir ./Sample --dest ./output --verbose
 ```
 Cloned repos end up in `DEST/repos/`. Add `CP_GIT_SHALLOW=0` to disable shallow clones.
+
+### Additional options
+
+- `--no-repo-update` &ndash; forwards the flag to `pod install` so CocoaPods skips updating the specs repos.
+
+The script leaves the CocoaPods specs repositories in their default location; only the library clone directories are captured via the patched `git.rb`.

--- a/Scripts/list_external_deps.sh
+++ b/Scripts/list_external_deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+LOCKFILE="${1:-}"
+if [[ -z "$LOCKFILE" ]]; then
+  echo "Usage: $0 /path/to/Podfile.lock" >&2
+  exit 1
+fi
+
+if [[ ! -f "$LOCKFILE" ]]; then
+  echo "Lockfile not found: $LOCKFILE" >&2
+  exit 1
+fi
+
+ruby -ryaml - "$LOCKFILE" <<'RUBY'
+lock = YAML.load_file(ARGV[0])
+external = lock["EXTERNAL SOURCES"] || {}
+checkout = lock["CHECKOUT OPTIONS"] || {}
+external.each do |name, info|
+  git = info[:git] || info["git"]
+  next unless git
+  co = checkout[name] || {}
+  tag = co[:tag] || co["tag"] || co[:commit] || co["commit"] || co[:branch] || co["branch"]
+  puts "#{name},#{git},#{tag}"
+end
+RUBY


### PR DESCRIPTION
## Summary
- add `--no-repo-update` flag to script and forward to `pod install`
- drop CP_HOME_DIR override so CocoaPods uses default specs repo
- document new option and behavior in README

## Testing
- `bash -n Scripts/fetch_pods.sh`
- `shellcheck Scripts/fetch_pods.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ade37df668832e896cd6f70763e6eb