### PR TITLE
Remove remote dependencies and vendor CommandLineKit

### DIFF
--- a/External/Firebase/Metrics/Package.swift
+++ b/External/Firebase/Metrics/Package.swift
@@ -21,7 +21,7 @@ import PackageDescription
 let package = Package(
   name: "Metrics",
   dependencies: [
-    .package(url: "https://github.com/objecthub/swift-commandlinekit", from: "0.2.5"),
+    .package(path: "../../swift-commandlinekit"),
   ],
   targets: [
     .target(

--- a/External/Firebase/ReleaseTooling/Package.swift
+++ b/External/Firebase/ReleaseTooling/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .executable(name: "zip-builder", targets: ["ZipBuilder"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.1.0")),
+    .package(path: "../../swift-argument-parser"),
   ],
   targets: [
     .target(

--- a/External/Firebase/scripts/create_spec_repo/Package.swift
+++ b/External/Firebase/scripts/create_spec_repo/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     .executable(name: "spec-repo-builder", targets: ["SpecRepoBuilder"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
+    .package(path: "../../../swift-argument-parser"),
   ],
   targets: [
     .target(

--- a/External/Firebase/scripts/health_metrics/generate_code_coverage_report/Package.swift
+++ b/External/Firebase/scripts/health_metrics/generate_code_coverage_report/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
+    .package(path: "../../../../swift-argument-parser"),
   ],
   targets: [
     .target(

--- a/External/Lottie/Package.swift
+++ b/External/Lottie/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0"), .custom("visionOS", versionString: "1.0")],
   products: [.library(name: "Lottie", targets: ["Lottie"])],
   dependencies: [
-    .package(url: "https://github.com/airbnb/swift", .upToNextMajor(from: "1.0.1")),
+    // Dependencies are vendored locally; no remote packages are required.
   ],
   targets: [
     .target(

--- a/External/ZIPFoundation/Package@swift-4.0.swift
+++ b/External/ZIPFoundation/Package@swift-4.0.swift
@@ -1,11 +1,8 @@
 // swift-tools-version:4.0
 import PackageDescription
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+// All dependencies are vendored locally; no remote package references are required.
 let dependencies: [Package.Dependency] = []
-#else
-let dependencies: [Package.Dependency] = [.package(url: "https://github.com/IBM-Swift/CZlib.git", .exact("0.1.2"))]
-#endif
 
 let package = Package(
     name: "ZIPFoundation",

--- a/External/ZIPFoundation/Package@swift-4.1.swift
+++ b/External/ZIPFoundation/Package@swift-4.1.swift
@@ -1,11 +1,8 @@
 // swift-tools-version:4.1
 import PackageDescription
 
-#if canImport(Compression)
+// All dependencies are vendored locally; no remote package references are required.
 let dependencies: [Package.Dependency] = []
-#else
-let dependencies: [Package.Dependency] = [.package(url: "https://github.com/IBM-Swift/CZlib.git", .exact("0.1.2"))]
-#endif
 
 let package = Package(
     name: "ZIPFoundation",

--- a/External/ZIPFoundation/Package@swift-4.2.swift
+++ b/External/ZIPFoundation/Package@swift-4.2.swift
@@ -1,11 +1,8 @@
 // swift-tools-version:4.2
 import PackageDescription
 
-#if canImport(Compression)
+// All dependencies are vendored locally; no remote package references are required.
 let dependencies: [Package.Dependency] = []
-#else
-let dependencies: [Package.Dependency] = [.package(url: "https://github.com/IBM-Swift/CZlib.git", .exact("0.1.2"))]
-#endif
 
 let package = Package(
     name: "ZIPFoundation",

--- a/External/swift-commandlinekit/.gitignore
+++ b/External/swift-commandlinekit/.gitignore
@@ -1,0 +1,54 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+.build
+Packages
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# macOS
+.DS_Store

--- a/External/swift-commandlinekit/CHANGELOG.md
+++ b/External/swift-commandlinekit/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+# 0.3.5 (2023-01-29)
+- Be more clever about detecting color terminals
+- Migrate project to Xcode 14.2
+
+## 0.3.4 (2021-05-12)
+- Minor bug fixes
+- Migrated project to Xcode 12.5
+
+## 0.3.3 (2020-10-04)
+- Ported code to Swift 5.3
+- Migrated project to Xcode 12.0
+
+## 0.3.2 (2020-02-01)
+- Fixed line reader to handle buffered output
+- Migrated project to Xcode 11.3
+
+## 0.3.1 (2019-09-23)
+- Migrated project to Xcode 11.0
+- Ported code to Swift 5.1
+
+## 0.3 (2019-03-30)
+- Migrated library to Xcode 10.2
+- Ported code to Swift 5
+
+## 0.2 (2018-06-10)
+- Bug fixes
+- Support of usage descriptions
+- Initial documentation
+
+## 0.1 (2018-05-14)
+- Initial version

--- a/External/swift-commandlinekit/CONTRIBUTING.md
+++ b/External/swift-commandlinekit/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution,
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).

--- a/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.pbxproj
+++ b/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.pbxproj
@@ -1,0 +1,814 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CC2324882087D9E4007D582B /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2324872087D9E4007D582B /* TextStyle.swift */; };
+		CC23248A2087DA70007D582B /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2324892087DA70007D582B /* BackgroundColor.swift */; };
+		CC23248C2087E6EB007D582B /* TextProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC23248B2087E6EB007D582B /* TextProperties.swift */; };
+		CC232490208945B8007D582B /* Terminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC23248F208945B8007D582B /* Terminal.swift */; };
+		CC3A9BC32A92E7D3005A305E /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3A9BC22A92E7D3005A305E /* Command.swift */; };
+		CC3A9BC52A92EA48005A305E /* FlagWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3A9BC42A92EA48005A305E /* FlagWrapper.swift */; };
+		CC74D3742AEB0E980054CC5A /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC74D3732AEB0E980054CC5A /* main.swift */; };
+		CC74D3792AEB0EC50054CC5A /* LinuxMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC74D3782AEB0EC50054CC5A /* LinuxMain.swift */; };
+		CC74D37B2AEB0EDD0054CC5A /* CommandLineKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */; };
+		CC74D37C2AEB0EDD0054CC5A /* CommandLineKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CCFC2AD7207A636B00EDDADD /* CommandLineKit.h in Headers */ = {isa = PBXBuildFile; fileRef = CCFC2AD5207A636B00EDDADD /* CommandLineKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCFC2AE1207A640700EDDADD /* Flag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AE0207A640700EDDADD /* Flag.swift */; };
+		CCFC2AE3207A662F00EDDADD /* Flags.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AE2207A662F00EDDADD /* Flags.swift */; };
+		CCFC2AE5207A693000EDDADD /* FlagError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AE4207A693000EDDADD /* FlagError.swift */; };
+		CCFC2AE7207A695B00EDDADD /* ConvertibleFromString.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AE6207A695B00EDDADD /* ConvertibleFromString.swift */; };
+		CCFC2AF1207A69B900EDDADD /* CommandLineKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */; };
+		CCFC2AF8207A69DE00EDDADD /* FlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AF7207A69DE00EDDADD /* FlagTests.swift */; };
+		CCFC2AFA207A6AAE00EDDADD /* ControlCharacters.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AF9207A6AAE00EDDADD /* ControlCharacters.swift */; };
+		CCFC2AFC207A6ACA00EDDADD /* LineReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AFB207A6ACA00EDDADD /* LineReader.swift */; };
+		CCFC2AFE207A6AF100EDDADD /* LineReaderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AFD207A6AF100EDDADD /* LineReaderError.swift */; };
+		CCFC2B00207A6B1000EDDADD /* TextColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2AFF207A6B1000EDDADD /* TextColor.swift */; };
+		CCFC2B02207A6B2C00EDDADD /* LineReaderHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B01207A6B2C00EDDADD /* LineReaderHistory.swift */; };
+		CCFC2B04207A6B4100EDDADD /* EditState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B03207A6B4100EDDADD /* EditState.swift */; };
+		CCFC2B06207A6B6700EDDADD /* AnsiCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B05207A6B6700EDDADD /* AnsiCodes.swift */; };
+		CCFC2B0C207A6FAD00EDDADD /* LineReaderHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B0B207A6FAD00EDDADD /* LineReaderHistoryTests.swift */; };
+		CCFC2B0E207A6FD600EDDADD /* EditStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B0D207A6FD600EDDADD /* EditStateTests.swift */; };
+		CCFC2B10207A6FFA00EDDADD /* AnsiCodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC2B0F207A6FFA00EDDADD /* AnsiCodesTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CC74D37D2AEB0EDD0054CC5A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CC7A60E0207A62A5007376A0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CCFC2AD2207A636B00EDDADD;
+			remoteInfo = CommandLineKit;
+		};
+		CCFC2AF2207A69B900EDDADD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CC7A60E0207A62A5007376A0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CCFC2AD2207A636B00EDDADD;
+			remoteInfo = CommandLineKit;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		CC74D36F2AEB0E980054CC5A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		CC74D37F2AEB0EDD0054CC5A /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				CC74D37C2AEB0EDD0054CC5A /* CommandLineKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		CC2324872087D9E4007D582B /* TextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
+		CC2324892087DA70007D582B /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
+		CC23248B2087E6EB007D582B /* TextProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextProperties.swift; sourceTree = "<group>"; };
+		CC23248F208945B8007D582B /* Terminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Terminal.swift; sourceTree = "<group>"; };
+		CC3A9BC22A92E7D3005A305E /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		CC3A9BC42A92EA48005A305E /* FlagWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagWrapper.swift; sourceTree = "<group>"; };
+		CC5E473020C4263400F21B03 /* LinuxMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = SOURCE_ROOT; };
+		CC74D3712AEB0E980054CC5A /* CommandLineKitDemo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CommandLineKitDemo; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC74D3732AEB0E980054CC5A /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		CC74D3782AEB0EC50054CC5A /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
+		CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CommandLineKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CCFC2AD5207A636B00EDDADD /* CommandLineKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommandLineKit.h; sourceTree = "<group>"; };
+		CCFC2AD6207A636B00EDDADD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CCFC2AE0207A640700EDDADD /* Flag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flag.swift; sourceTree = "<group>"; };
+		CCFC2AE2207A662F00EDDADD /* Flags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flags.swift; sourceTree = "<group>"; };
+		CCFC2AE4207A693000EDDADD /* FlagError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagError.swift; sourceTree = "<group>"; };
+		CCFC2AE6207A695B00EDDADD /* ConvertibleFromString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertibleFromString.swift; sourceTree = "<group>"; };
+		CCFC2AEC207A69B900EDDADD /* CommandLineKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommandLineKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CCFC2AF0207A69B900EDDADD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CCFC2AF7207A69DE00EDDADD /* FlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagTests.swift; sourceTree = "<group>"; };
+		CCFC2AF9207A6AAE00EDDADD /* ControlCharacters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCharacters.swift; sourceTree = "<group>"; };
+		CCFC2AFB207A6ACA00EDDADD /* LineReader.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = LineReader.swift; sourceTree = "<group>"; };
+		CCFC2AFD207A6AF100EDDADD /* LineReaderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineReaderError.swift; sourceTree = "<group>"; };
+		CCFC2AFF207A6B1000EDDADD /* TextColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextColor.swift; sourceTree = "<group>"; };
+		CCFC2B01207A6B2C00EDDADD /* LineReaderHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineReaderHistory.swift; sourceTree = "<group>"; };
+		CCFC2B03207A6B4100EDDADD /* EditState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditState.swift; sourceTree = "<group>"; };
+		CCFC2B05207A6B6700EDDADD /* AnsiCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiCodes.swift; sourceTree = "<group>"; };
+		CCFC2B07207A6BFB00EDDADD /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		CCFC2B08207A6C2200EDDADD /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		CCFC2B09207A6C3B00EDDADD /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		CCFC2B0A207A6C5700EDDADD /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		CCFC2B0B207A6FAD00EDDADD /* LineReaderHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineReaderHistoryTests.swift; sourceTree = "<group>"; };
+		CCFC2B0D207A6FD600EDDADD /* EditStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStateTests.swift; sourceTree = "<group>"; };
+		CCFC2B0F207A6FFA00EDDADD /* AnsiCodesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiCodesTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CC74D36E2AEB0E980054CC5A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC74D37B2AEB0EDD0054CC5A /* CommandLineKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCFC2ACF207A636B00EDDADD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCFC2AE9207A69B900EDDADD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCFC2AF1207A69B900EDDADD /* CommandLineKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CC74D3722AEB0E980054CC5A /* CommandLineKitDemo */ = {
+			isa = PBXGroup;
+			children = (
+				CC74D3732AEB0E980054CC5A /* main.swift */,
+				CC74D3782AEB0EC50054CC5A /* LinuxMain.swift */,
+			);
+			name = CommandLineKitDemo;
+			path = Sources/CommandLineKitDemo;
+			sourceTree = "<group>";
+		};
+		CC74D37A2AEB0EDD0054CC5A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CC7A60DF207A62A5007376A0 = {
+			isa = PBXGroup;
+			children = (
+				CCFC2B07207A6BFB00EDDADD /* README.md */,
+				CCFC2B08207A6C2200EDDADD /* CHANGELOG.md */,
+				CCFC2B09207A6C3B00EDDADD /* LICENSE */,
+				CCFC2B0A207A6C5700EDDADD /* Package.swift */,
+				CCFC2AD4207A636B00EDDADD /* CommandLineKit */,
+				CCFC2AED207A69B900EDDADD /* CommandLineKitTests */,
+				CC74D3722AEB0E980054CC5A /* CommandLineKitDemo */,
+				CC7A60E8207A62A5007376A0 /* Products */,
+				CC74D37A2AEB0EDD0054CC5A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		CC7A60E8207A62A5007376A0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */,
+				CCFC2AEC207A69B900EDDADD /* CommandLineKitTests.xctest */,
+				CC74D3712AEB0E980054CC5A /* CommandLineKitDemo */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CCFC2AD4207A636B00EDDADD /* CommandLineKit */ = {
+			isa = PBXGroup;
+			children = (
+				CCFC2AE0207A640700EDDADD /* Flag.swift */,
+				CCFC2AE2207A662F00EDDADD /* Flags.swift */,
+				CCFC2AE4207A693000EDDADD /* FlagError.swift */,
+				CC3A9BC42A92EA48005A305E /* FlagWrapper.swift */,
+				CC3A9BC22A92E7D3005A305E /* Command.swift */,
+				CCFC2AE6207A695B00EDDADD /* ConvertibleFromString.swift */,
+				CC23248F208945B8007D582B /* Terminal.swift */,
+				CC23248B2087E6EB007D582B /* TextProperties.swift */,
+				CCFC2AFF207A6B1000EDDADD /* TextColor.swift */,
+				CC2324872087D9E4007D582B /* TextStyle.swift */,
+				CC2324892087DA70007D582B /* BackgroundColor.swift */,
+				CCFC2AFB207A6ACA00EDDADD /* LineReader.swift */,
+				CCFC2AFD207A6AF100EDDADD /* LineReaderError.swift */,
+				CCFC2B01207A6B2C00EDDADD /* LineReaderHistory.swift */,
+				CCFC2B03207A6B4100EDDADD /* EditState.swift */,
+				CCFC2B05207A6B6700EDDADD /* AnsiCodes.swift */,
+				CCFC2AF9207A6AAE00EDDADD /* ControlCharacters.swift */,
+				CCFC2AD5207A636B00EDDADD /* CommandLineKit.h */,
+				CCFC2AD6207A636B00EDDADD /* Info.plist */,
+			);
+			name = CommandLineKit;
+			path = Sources/CommandLineKit;
+			sourceTree = "<group>";
+		};
+		CCFC2AED207A69B900EDDADD /* CommandLineKitTests */ = {
+			isa = PBXGroup;
+			children = (
+				CCFC2AF7207A69DE00EDDADD /* FlagTests.swift */,
+				CCFC2B0B207A6FAD00EDDADD /* LineReaderHistoryTests.swift */,
+				CCFC2B0D207A6FD600EDDADD /* EditStateTests.swift */,
+				CCFC2B0F207A6FFA00EDDADD /* AnsiCodesTests.swift */,
+				CC5E473020C4263400F21B03 /* LinuxMain.swift */,
+				CCFC2AF0207A69B900EDDADD /* Info.plist */,
+			);
+			name = CommandLineKitTests;
+			path = Tests/CommandLineKitTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		CCFC2AD0207A636B00EDDADD /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCFC2AD7207A636B00EDDADD /* CommandLineKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		CC74D3702AEB0E980054CC5A /* CommandLineKitDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC74D3752AEB0E980054CC5A /* Build configuration list for PBXNativeTarget "CommandLineKitDemo" */;
+			buildPhases = (
+				CC74D36D2AEB0E980054CC5A /* Sources */,
+				CC74D36E2AEB0E980054CC5A /* Frameworks */,
+				CC74D36F2AEB0E980054CC5A /* CopyFiles */,
+				CC74D37F2AEB0EDD0054CC5A /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC74D37E2AEB0EDD0054CC5A /* PBXTargetDependency */,
+			);
+			name = CommandLineKitDemo;
+			productName = CommandLineKitDemo;
+			productReference = CC74D3712AEB0E980054CC5A /* CommandLineKitDemo */;
+			productType = "com.apple.product-type.tool";
+		};
+		CCFC2AD2207A636B00EDDADD /* CommandLineKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCFC2ADE207A636B00EDDADD /* Build configuration list for PBXNativeTarget "CommandLineKit" */;
+			buildPhases = (
+				CCFC2ACE207A636B00EDDADD /* Sources */,
+				CCFC2ACF207A636B00EDDADD /* Frameworks */,
+				CCFC2AD0207A636B00EDDADD /* Headers */,
+				CCFC2AD1207A636B00EDDADD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CommandLineKit;
+			productName = CommandLineKit;
+			productReference = CCFC2AD3207A636B00EDDADD /* CommandLineKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CCFC2AEB207A69B900EDDADD /* CommandLineKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCFC2AF4207A69B900EDDADD /* Build configuration list for PBXNativeTarget "CommandLineKitTests" */;
+			buildPhases = (
+				CCFC2AE8207A69B900EDDADD /* Sources */,
+				CCFC2AE9207A69B900EDDADD /* Frameworks */,
+				CCFC2AEA207A69B900EDDADD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CCFC2AF3207A69B900EDDADD /* PBXTargetDependency */,
+			);
+			name = CommandLineKitTests;
+			productName = CommandLineKitTests;
+			productReference = CCFC2AEC207A69B900EDDADD /* CommandLineKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CC7A60E0207A62A5007376A0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				ORGANIZATIONNAME = "Matthias Zenger";
+				TargetAttributes = {
+					CC74D3702AEB0E980054CC5A = {
+						CreatedOnToolsVersion = 15.0.1;
+					};
+					CCFC2AD2207A636B00EDDADD = {
+						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1020;
+					};
+					CCFC2AEB207A69B900EDDADD = {
+						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1020;
+					};
+				};
+			};
+			buildConfigurationList = CC7A60E3207A62A5007376A0 /* Build configuration list for PBXProject "CommandLineKit" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CC7A60DF207A62A5007376A0;
+			productRefGroup = CC7A60E8207A62A5007376A0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CCFC2AD2207A636B00EDDADD /* CommandLineKit */,
+				CCFC2AEB207A69B900EDDADD /* CommandLineKitTests */,
+				CC74D3702AEB0E980054CC5A /* CommandLineKitDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CCFC2AD1207A636B00EDDADD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCFC2AEA207A69B900EDDADD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CC74D36D2AEB0E980054CC5A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC74D3742AEB0E980054CC5A /* main.swift in Sources */,
+				CC74D3792AEB0EC50054CC5A /* LinuxMain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCFC2ACE207A636B00EDDADD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC2324882087D9E4007D582B /* TextStyle.swift in Sources */,
+				CCFC2AE1207A640700EDDADD /* Flag.swift in Sources */,
+				CCFC2B04207A6B4100EDDADD /* EditState.swift in Sources */,
+				CCFC2AE5207A693000EDDADD /* FlagError.swift in Sources */,
+				CCFC2AE7207A695B00EDDADD /* ConvertibleFromString.swift in Sources */,
+				CC232490208945B8007D582B /* Terminal.swift in Sources */,
+				CCFC2AE3207A662F00EDDADD /* Flags.swift in Sources */,
+				CC3A9BC32A92E7D3005A305E /* Command.swift in Sources */,
+				CCFC2B02207A6B2C00EDDADD /* LineReaderHistory.swift in Sources */,
+				CCFC2AFC207A6ACA00EDDADD /* LineReader.swift in Sources */,
+				CCFC2B06207A6B6700EDDADD /* AnsiCodes.swift in Sources */,
+				CC23248C2087E6EB007D582B /* TextProperties.swift in Sources */,
+				CCFC2B00207A6B1000EDDADD /* TextColor.swift in Sources */,
+				CC23248A2087DA70007D582B /* BackgroundColor.swift in Sources */,
+				CCFC2AFE207A6AF100EDDADD /* LineReaderError.swift in Sources */,
+				CCFC2AFA207A6AAE00EDDADD /* ControlCharacters.swift in Sources */,
+				CC3A9BC52A92EA48005A305E /* FlagWrapper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCFC2AE8207A69B900EDDADD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCFC2AF8207A69DE00EDDADD /* FlagTests.swift in Sources */,
+				CCFC2B0E207A6FD600EDDADD /* EditStateTests.swift in Sources */,
+				CCFC2B0C207A6FAD00EDDADD /* LineReaderHistoryTests.swift in Sources */,
+				CCFC2B10207A6FFA00EDDADD /* AnsiCodesTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CC74D37E2AEB0EDD0054CC5A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CCFC2AD2207A636B00EDDADD /* CommandLineKit */;
+			targetProxy = CC74D37D2AEB0EDD0054CC5A /* PBXContainerItemProxy */;
+		};
+		CCFC2AF3207A69B900EDDADD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CCFC2AD2207A636B00EDDADD /* CommandLineKit */;
+			targetProxy = CCFC2AF2207A69B900EDDADD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CC74D3762AEB0E980054CC5A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKitDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		CC74D3772AEB0E980054CC5A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKitDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		CC7A60ED207A62A5007376A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		CC7A60EE207A62A5007376A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		CCFC2ADC207A636B00EDDADD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/CommandLineKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		CCFC2ADD207A636B00EDDADD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/CommandLineKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		CCFC2AF5207A69B900EDDADD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/CommandLineKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		CCFC2AF6207A69B900EDDADD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/CommandLineKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.objecthub.CommandLineKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CC74D3752AEB0E980054CC5A /* Build configuration list for PBXNativeTarget "CommandLineKitDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC74D3762AEB0E980054CC5A /* Debug */,
+				CC74D3772AEB0E980054CC5A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC7A60E3207A62A5007376A0 /* Build configuration list for PBXProject "CommandLineKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC7A60ED207A62A5007376A0 /* Debug */,
+				CC7A60EE207A62A5007376A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CCFC2ADE207A636B00EDDADD /* Build configuration list for PBXNativeTarget "CommandLineKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CCFC2ADC207A636B00EDDADD /* Debug */,
+				CCFC2ADD207A636B00EDDADD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CCFC2AF4207A69B900EDDADD /* Build configuration list for PBXNativeTarget "CommandLineKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CCFC2AF5207A69B900EDDADD /* Debug */,
+				CCFC2AF6207A69B900EDDADD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CC7A60E0207A62A5007376A0 /* Project object */;
+}

--- a/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:../Tests/CommandLineKitTests">
+   </FileRef>
+</Workspace>

--- a/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/External/swift-commandlinekit/CommandLineKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/External/swift-commandlinekit/CommandLineKit.xcodeproj/xcshareddata/xcschemes/CommandLineKit.xcscheme
+++ b/External/swift-commandlinekit/CommandLineKit.xcodeproj/xcshareddata/xcschemes/CommandLineKit.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCFC2AD2207A636B00EDDADD"
+               BuildableName = "CommandLineKit.framework"
+               BlueprintName = "CommandLineKit"
+               ReferencedContainer = "container:CommandLineKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CCFC2AD2207A636B00EDDADD"
+            BuildableName = "CommandLineKit.framework"
+            BlueprintName = "CommandLineKit"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCFC2AEB207A69B900EDDADD"
+               BuildableName = "CommandLineKitTests.xctest"
+               BlueprintName = "CommandLineKitTests"
+               ReferencedContainer = "container:CommandLineKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CCFC2AD2207A636B00EDDADD"
+            BuildableName = "CommandLineKit.framework"
+            BlueprintName = "CommandLineKit"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CCFC2AD2207A636B00EDDADD"
+            BuildableName = "CommandLineKit.framework"
+            BlueprintName = "CommandLineKit"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/External/swift-commandlinekit/CommandLineKit.xcodeproj/xcshareddata/xcschemes/CommandLineKitDemo.xcscheme
+++ b/External/swift-commandlinekit/CommandLineKit.xcodeproj/xcshareddata/xcschemes/CommandLineKitDemo.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC74D3702AEB0E980054CC5A"
+               BuildableName = "CommandLineKitDemo"
+               BlueprintName = "CommandLineKitDemo"
+               ReferencedContainer = "container:CommandLineKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC74D3702AEB0E980054CC5A"
+            BuildableName = "CommandLineKitDemo"
+            BlueprintName = "CommandLineKitDemo"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCFC2AEB207A69B900EDDADD"
+               BuildableName = "CommandLineKitTests.xctest"
+               BlueprintName = "CommandLineKitTests"
+               ReferencedContainer = "container:CommandLineKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC74D3702AEB0E980054CC5A"
+            BuildableName = "CommandLineKitDemo"
+            BlueprintName = "CommandLineKitDemo"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TERM"
+            value = "xcode"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC74D3702AEB0E980054CC5A"
+            BuildableName = "CommandLineKitDemo"
+            BlueprintName = "CommandLineKitDemo"
+            ReferencedContainer = "container:CommandLineKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/External/swift-commandlinekit/CommandLineKitDemo/main.swift
+++ b/External/swift-commandlinekit/CommandLineKitDemo/main.swift
@@ -1,0 +1,12 @@
+//
+//  main.swift
+//  CommandLineKitDemo
+//
+//  Created by Matthias Zenger on 26/10/2023.
+//  Copyright © 2023 Matthias Zenger. All rights reserved.
+//
+
+import Foundation
+
+print("Hello, World!")
+

--- a/External/swift-commandlinekit/LICENSE
+++ b/External/swift-commandlinekit/LICENSE
@@ -1,0 +1,29 @@
+Copyright © 2018-2019 Google LLC
+Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/External/swift-commandlinekit/Package.swift
+++ b/External/swift-commandlinekit/Package.swift
@@ -1,0 +1,66 @@
+// swift-tools-version:5.4
+//
+//  Package.swift
+//  CommandLineKit
+//
+//  Build targets by calling the Swift Package Manager in the following way for debug purposes:
+//  swift build
+//
+//  A release can be built with these options:
+//  swift build -c release
+//
+//  Created by Matthias Zenger on 06/05/2017.
+//  Copyright © 2018-2023 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import PackageDescription
+
+let package = Package(
+  name: "CommandLineKit",
+  platforms: [
+    .macOS(.v11)
+  ],
+  products: [
+    .library(name: "CommandLineKit", targets: ["CommandLineKit"]),
+    .executable(name: "CommandLineKitDemo", targets: ["CommandLineKitDemo"])
+  ],
+  dependencies: [
+  ],
+  targets: [
+    .target(name: "CommandLineKit",
+            dependencies: [],
+            exclude: ["Info.plist"]),
+    .executableTarget(name: "CommandLineKitDemo",
+                      dependencies: ["CommandLineKit"],
+                      exclude: []),
+    .testTarget(name: "CommandLineKitTests",
+                dependencies: ["CommandLineKit"],
+                exclude: ["Info.plist"])
+  ],
+  swiftLanguageVersions: [.v5]
+)

--- a/External/swift-commandlinekit/README.md
+++ b/External/swift-commandlinekit/README.md
@@ -1,0 +1,307 @@
+# Swift CommandLineKit
+
+[![Platform: macOS](https://img.shields.io/badge/Platform-macOS-blue.svg?style=flat)](https://developer.apple.com/osx/)
+[![Platform: Linux](https://img.shields.io/badge/Platform-Linux-blue.svg?style=flat)](https://www.ubuntu.com/)
+[![Language: Swift 5.8](https://img.shields.io/badge/Language-Swift%205.8-green.svg?style=flat)](https://developer.apple.com/swift/)
+[![IDE: Xcode 14](https://img.shields.io/badge/IDE-Xcode%2014-orange.svg?style=flat)](https://developer.apple.com/xcode/)
+[![Carthage: compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![License: BSD](https://img.shields.io/badge/License-BSD-lightgrey.svg?style=flat)](https://developers.google.com/open-source/licenses/bsd)
+
+## Overview
+
+This is a library supporting the development of command-line tools in
+the programming language Swift on macOS. It also compiles under Linux.
+The library provides the following functionality:
+
+   - Management of command-line arguments,
+   - Usage of escape sequences on terminals, and
+   - Reading strings on terminals using a lineread-inspired implementation
+     based on the library [Linenoise-Swift](https://github.com/andybest/linenoise-swift),
+     but supporting unicode input, multiple lines, and styled text.
+
+## Command-line arguments
+
+### Basics
+
+CommandLineKit handles command-line arguments with the following protocol:
+
+   1. A new [Flags](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/Flags.swift)
+      object gets created either for the system-provided command-line arguments or for a
+      custom sequence of arguments.
+   2. For every flag, a [Flag](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/Flag.swift)
+       object is being created and registered in the `Flags` object.
+   3. Once all flag objects are declared and registered, the command-line gets parsed. After parsing
+      is complete, the flag objects can be used to access the extracted options and arguments.
+
+CommandLineKit defines different types of
+[Flag](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/Flag.swift)
+subclasses for handling _options_ (i.e. flags without
+parameters) and _arguments_ (i.e. flags with parameters). Arguments are either _singleton arguments_ (i.e. they
+have exactly one value) or they are _repeated arguments_ (i.e. they have many values). Arguments are
+parameterized with a type which defines how to parse values. The framework natively supports _int_,
+_double_, _string_, and _enum_ types, which means that in practice, just using the built-in flag classes
+are almost always sufficient. Nevertheless,
+[the framework is extensible](https://github.com/objecthub/swift-commandlinekit/tree/master/Sources/CommandLineKit)
+and supports arbitrary argument types.
+
+A flag is identified by a _short name_ character and a _long name_ string. At least one of the two needs to be
+defined. For instance, the "help" option could be defined by the short name "h" and the long name "help".
+On the command-line, a user could either use `-h` or `--help` to refer to this option; i.e. short names are
+prefixed with a single dash, long names are prefixed with a double dash.
+
+An argument is a parameterized flag. The parameters follow directly the flag identifier (typically separated by
+a space). For instance, an integer argument with long name "size" could be defined as: `--size 64`. If the
+argument is repeated, then multiple parameters may follow the flag identifier, as in this
+example: `--size 2 4 8 16`. The sequence is terminated by either the end of the command-line arguments,
+another flag, or the terminator "---". All command-line arguments following the terminator are not being parsed
+and are returned in the `parameters` field of the `Flags` object.
+
+### Programmatic API
+
+Here is an [example](https://github.com/objecthub/swift-lispkit/blob/master/Sources/LispKitRepl/main.swift)
+from the [LispKit](https://github.com/objecthub/swift-lispkit) project. It uses factory methods (like `flags.string`,
+`flags.int`, `flags.option`, `flags.strings`, etc.) provided by the
+[Flags](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/Flags.swift)
+class to create and register individual flags.
+
+```swift
+// Create a new flags object for the system-provided command-line arguments
+var flags = Flags()
+
+// Define the various flags
+let filePaths  = flags.strings("f", "filepath",
+                               description: "Adds file path in which programs are searched for.")
+let libPaths   = flags.strings("l", "libpath",
+                               description: "Adds file path in which libraries are searched for.")
+let heapSize   = flags.int("x", "heapsize",
+                           description: "Initial capacity of the heap", value: 1000)
+let importLibs = flags.strings("i", "import",
+                               description: "Imports library automatically after startup.")
+let prelude    = flags.string("p", "prelude",
+                              description: "Path to prelude file which gets executed after " +
+                                           "loading all provided libraries.")
+let prompt     = flags.string("r", "prompt",
+                              description: "String used as prompt in REPL.", value: "> ")
+let quiet      = flags.option("q", "quiet",
+                              description: "In quiet mode, optional messages are not printed.")
+let help       = flags.option("h", "help",
+                              description: "Show description of usage and options of this tools.")
+
+// Parse the command-line arguments and return error message if parsing fails
+if let failure = flags.parsingFailure() {
+  print(failure)
+  exit(1)
+}
+```
+
+The framework supports printing the supported options via the `Flags.usageDescription` function. For the
+command-line flags as defined above, this function returns the following usage description:
+
+```
+usage: LispKitRepl [<option> ...] [---] [<program> <arg> ...]
+options:
+  -f, --filepath <value> ...
+      Adds file path in which programs are searched for.
+  -l, --libpath <value> ...
+      Adds file path in which libraries are searched for.
+  -h, --heapsize <value>
+      Initial capacity of the heap
+  -i, --import <value> ...
+      Imports library automatically after startup.
+  -p, --prelude <value>
+      Path to prelude file which gets executed after loading all provided libraries.
+  -r, --prompt <value>
+      String used as prompt in REPL.
+  -q, --quiet
+      In quiet mode, optional messages are not printed.
+  -h, --help
+      Show description of usage and options of this tools.
+```
+
+Command-line tools can inspect whether a flag was set via the `Flag.wasSet` field. For flags with
+parameters, the parameters are stored in the `Flag.value` field. The type of this field is dependent on the
+flag type. For repeated flags, an array is used.
+
+Here is an example how the flags defined by the code snippet above could be used:
+
+```swift
+// If help flag was provided, print usage description and exit tool
+if help.wasSet {
+  print(flags.usageDescription(usageName: TextStyle.bold.properties.apply(to: "usage:"),
+                               synopsis: "[<option> ...] [---] [<program> <arg> ...]",
+                               usageStyle: TextProperties.none,
+                               optionsName: TextStyle.bold.properties.apply(to: "options:"),
+                               flagStyle: TextStyle.italic.properties),
+        terminator: "")
+  exit(0)
+}
+...
+// Define how optional messages and errors are printed
+func printOpt(_ message: String) {
+  if !quiet.wasSet {
+    print(message)
+  }
+}
+...
+// Set heap size (assuming 1234 is the default if the flag is not set)
+virtualMachine.setHeapSize(heapSize.value ?? 1234)
+...
+// Register all file paths
+for path in filePaths.value {
+  virtualMachine.fileHandler.register(path)
+}
+...
+// Load prelude file if it was provided via flag `prelude`
+if let file = prelude.value {
+  virtualMachine.load(file)
+}
+```
+
+### Declarative API
+
+The code below illustrates how to combine the `Command` protocol with property wrappers
+declaring the various command-line flags. The whole lifecycle of a command-line tool that
+is declared like this will be managed automatically. After flags are being parsed, either
+methods `run()` or `fail(with:)` are being called (depending on whether flag parsing
+succeeds or fails).
+
+```swift
+@main struct LispKitRepl: Command {
+  @CommandArguments(short: "f", description: "Adds file path in which programs are searched for.")
+  var filePath: [String]
+  @CommandArguments(short: "l", description: "Adds file path in which libraries are searched for.")
+  var libPaths: [String]
+  @CommandArgument(short: "x", description: "Initial capacity of the heap")
+  var heapSize: Int = 1234
+  ...
+  @CommandOption(short: "h", description: "Show description of usage and options of this tools.")
+  var help: Bool
+  @CommandParameters // Inject the unparsed parameters
+  var params: [String]
+  @CommandFlags // Inject the flags object
+  var flags: Flags
+  
+  mutating func fail(with reason: String) throws {
+    print(reason)
+    exit(1)
+  }
+  
+  mutating func run() throws {
+    // If help flag was provided, print usage description and exit tool
+    if help {
+      print(flags.usageDescription(usageName: TextStyle.bold.properties.apply(to: "usage:"),
+                                   synopsis: "[<option> ...] [---] [<program> <arg> ...]",
+                                   usageStyle: TextProperties.none,
+                                   optionsName: TextStyle.bold.properties.apply(to: "options:"),
+                                   flagStyle: TextStyle.italic.properties),
+            terminator: "")
+      exit(0)
+    }
+    ...
+    // Define how optional messages and errors are printed
+    func printOpt(_ message: String) {
+      if !quiet {
+        print(message)
+      }
+    }
+    ...
+    // Set heap size
+    virtualMachine.setHeapSize(heapSize)
+    ...
+    // Register all file paths
+    for path in filePaths {
+      virtualMachine.fileHandler.register(path)
+    }
+    ...
+    // Load prelude file if it was provided via flag `prelude`
+    if let file = prelude {
+      virtualMachine.load(file)
+    }
+  }
+}
+```
+
+## Text style and colors
+
+CommandLineKit provides a
+[TextProperties](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/TextProperties.swift)
+structure for bundling a text color, a background color, and a text style in a single object. Text properties can be
+merged with the `with(:)` functions and applied to a string with the `apply(to:)` function.
+
+Individual enumerations for
+[TextColor](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/TextColor.swift),
+[BackgroundColor](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/BackgroundColor.swift), and
+[TextStyle](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/TextStyle.swift)
+define the individual properties.
+
+## Reading strings
+
+CommandLineKit includes a significantly improved version of the "readline" API originally defined by the library
+[Linenoise-Swift](https://github.com/andybest/linenoise-swift). It supports unicode text, multi-line text entry, and
+styled text. It supports all the existing features such as _advanced keyboard support_, _history_,
+_text completion_, and _hints_.
+
+The following code illustrates the usage of the
+[LineReader](https://github.com/objecthub/swift-commandlinekit/blob/master/Sources/CommandLineKit/LineReader.swift) API:
+
+```swift
+if let ln = LineReader() {
+  ln.setCompletionCallback { currentBuffer in
+    let completions = [
+      "Hello!",
+      "Hello Google",
+      "Scheme is awesome!"
+    ]
+    return completions.filter { $0.hasPrefix(currentBuffer) }
+  }
+  ln.setHintsCallback { currentBuffer in
+    let hints = [
+      "Foo",
+      "Lorem Ipsum",
+      "Scheme is awesome!"
+    ]
+    let filtered = hints.filter { $0.hasPrefix(currentBuffer) }
+    if let hint = filtered.first {
+      let hintText = String(hint.dropFirst(currentBuffer.count))
+      return (hintText, TextColor.grey.properties)
+    } else {
+      return nil
+    }
+  }
+  print("Type 'exit' to quit")
+  var done = false
+  while !done {
+    do {
+      let output = try ln.readLine(prompt: "> ",
+                                   maxCount: 200,
+                                   strippingNewline: true,
+                                   promptProperties: TextProperties(.green, nil, .bold),
+                                   readProperties: TextProperties(.blue, nil),
+                                   parenProperties: TextProperties(.red, nil, .bold))
+      print("Entered: \(output)")
+      ln.addHistory(output)
+      if output == "exit" {
+        break
+      }
+    } catch LineReaderError.CTRLC {
+      print("\nCaptured CTRL+C. Quitting.")
+      done = true
+    } catch {
+      print(error)
+    }
+  }
+}
+```
+
+## Requirements
+
+- [Xcode 14](https://developer.apple.com/xcode/)
+- [Swift 5.8](https://developer.apple.com/swift/)
+- [Carthage](https://github.com/Carthage/Carthage)
+- [Swift Package Manager](https://swift.org/package-manager/)
+
+## Copyright
+
+Author: Matthias Zenger (<matthias@objecthub.com>)  
+Copyright © 2018-2023 Google LLC.  
+_Please note: This is not an official Google product._

--- a/External/swift-commandlinekit/Sources/CommandLineKit/AnsiCodes.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/AnsiCodes.swift
@@ -1,0 +1,122 @@
+//
+//  AnsiCodes.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+public struct AnsiCodes {
+  public static let CSI: String = "\u{001B}["
+  
+  public static let eraseRight: String = escapeCode("0K")
+  public static let homeCursor: String = escapeCode("H")
+  
+  /// The following line is a hack. It is the only reliable way I could get "Terminal.app" on
+  /// macOS to return to the beginning of the line
+  public static let beginningOfLine: String = cursorBackward(3000) + cursorBackward(999)
+  public static let endOfLine: String = cursorForward(3000) + cursorForward(999)
+  
+  /// Clear screen
+  public static let clearScreen: String = escapeCode("2J")
+  public static let clearCursorToBottom: String = escapeCode("0J")
+  public static let clearTopToCursor: String = escapeCode("1J")
+  
+  /// Clear line
+  public static let clearLine: String = escapeCode("2K")
+  public static let clearCursorToEnd: String = escapeCode("0K")
+  public static let clearBeginningToCursor: String = escapeCode("1K")
+  
+  /// Save/restore cursor position
+  public static let savePos: String = escapeCode("s")
+  public static let restorePos: String = escapeCode("u")
+  
+  public static let cursorLocation: String = escapeCode("6n")
+  public static let origTermColor: String = escapeCode("0m")
+  
+  public static func escapeCode(_ input: String) -> String {
+    return AnsiCodes.CSI + input
+  }
+  
+  public static func setCursorColumn(_ column: Int) -> String {
+    return escapeCode("\(column)G")
+  }
+  
+  public static func setCursorPos(_ row: Int, _ column: Int) -> String {
+    return escapeCode("\(row);\(column)H")
+  }
+  
+  public static func cursorUp(_ rows: Int) -> String {
+    guard rows > 0 else {
+      return ""
+    }
+    return escapeCode("\(rows)A")
+  }
+  
+  public static func cursorDown(_ rows: Int) -> String {
+    guard rows > 0 else {
+      return ""
+    }
+    return escapeCode("\(rows)B")
+  }
+  
+  public static func cursorForward(_ columns: Int) -> String {
+    guard columns > 0 else {
+      return ""
+    }
+    return escapeCode("\(columns)C")
+  }
+  
+  public static func cursorBackward(_ columns: Int) -> String {
+    guard columns > 0 else {
+      return ""
+    }
+    return escapeCode("\(columns)D")
+  }
+  
+  public static func nextLine(_ lines: Int) -> String {
+    return escapeCode("\(lines)E")
+  }
+  
+  public static func previousLine(_ lines: Int) -> String {
+    return escapeCode("\(lines)F")
+  }
+  
+  public static func termColor(color: Int, bold: Bool) -> String {
+    return escapeCode("\(color);\(bold ? 1 : 0);49m")
+  }
+  
+  public static func termColor256(color: Int) -> String {
+    return escapeCode("38;5;\(color)m")
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/BackgroundColor.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/BackgroundColor.swift
@@ -1,0 +1,122 @@
+//
+//  BackgroundColor.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 18/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+public enum BackgroundColor: Hashable {
+  case black
+  case red
+  case green
+  case yellow
+  case blue
+  case magenta
+  case cyan
+  case white
+  case `default`
+  case extended(UInt8)
+  
+  public init?(colorCode: UInt8, fullColorSupport all256: Bool = false) {
+    if all256 {
+      self = .extended(colorCode)
+    } else {
+      switch colorCode {
+        case 40:
+          self = .black
+        case 41:
+          self = .red
+        case 42:
+          self = .green
+        case 43:
+          self = .yellow
+        case 44:
+          self = .blue
+        case 45:
+          self = .magenta
+        case 46:
+          self = .cyan
+        case 47:
+          self = .white
+        case 49:
+          self = .default
+        default:
+          return nil
+      }
+    }
+  }
+  
+  public init(color: (UInt8, UInt8, UInt8), fullColorSupport all256: Bool = false) {
+    let code = Terminal.closestColor(to: color, fullColorSupport: all256)
+    if all256 {
+      self = .extended(code)
+    } else {
+      let color: BackgroundColor? = code < 8 ? BackgroundColor(colorCode: code + 40) : nil
+      self = color ?? .default
+    }
+  }
+  
+  public var code: UInt8 {
+    switch self {
+      case .black:
+        return 40
+      case .red:
+        return 41
+      case .green:
+        return 42
+      case .yellow:
+        return 43
+      case .blue:
+        return 44
+      case .magenta:
+        return 45
+      case .cyan:
+        return 46
+      case .white:
+        return 47
+      case .default:
+        return 49
+      case .extended(let c):
+        return c
+    }
+  }
+  
+  public var isExtended: Bool {
+    guard case .extended(_) = self else {
+      return false
+    }
+    return true
+  }
+  
+  public var properties: TextProperties {
+    return TextProperties(backgroundColor: self)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/Command.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/Command.swift
@@ -1,0 +1,168 @@
+//
+//  Command.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 20/08/2023.
+//  Copyright © 2023 Matthias Zenger. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+///
+/// The command protocol implements an API for command-line tools. A `Flags` object
+/// gets automatically instantiated and flags, declared with flag property wrappers,
+/// are automatically registered with the `Flags` object. If flag parsing results in
+/// an error, the `fail(with: String)` method is called. Otherwise, `run()` gets
+/// executed.
+/// 
+public protocol Command {
+  static var name: String { get }
+  static var arguments: [String] { get }
+  init()
+  mutating func run() throws
+  mutating func fail(with: String) throws
+}
+
+extension Command {
+  
+  public mutating func fail(with reason: String) {
+    print(reason)
+    exit(1)
+  }
+  
+  public static var name: String {
+    if let toolPath = CommandLine.arguments.first {
+      return URL(fileURLWithPath: toolPath).lastPathComponent
+    } else {
+      let str = String(describing: self)
+      if let i = str.firstIndex(of: "("), i > str.startIndex, i < str.endIndex {
+        return String(str[str.startIndex..<i])
+      } else {
+        return str
+      }
+    }
+  }
+  
+  public static var arguments: [String] {
+    var args = CommandLine.arguments
+    args.removeFirst()
+    return args
+  }
+  
+  public static func newFlags() -> Flags {
+    return Flags(toolName: Self.name, arguments: Self.arguments)
+  }
+  
+  public static func argumentNameConverter() -> ArgumentNameConverter {
+    return ArgumentNameConverter(Self.argumentNamingStrategy())
+  }
+  
+  public static func argumentNamingStrategy() -> ArgumentNameConverter.Strategy {
+    return .lowercase
+  }
+  
+  public static func main() throws {
+    var command = Self()
+    let flags = Self.newFlags()
+    let converter = Self.argumentNameConverter()
+    let children = Mirror(reflecting: command).children
+    for child in children {
+      if let wrapper = child.value as? FlagWrapper {
+        if let label = child.label {
+          if label.hasPrefix("_") {
+            wrapper.register(as: converter.convert(String(label.dropFirst())), with: flags)
+          } else {
+            wrapper.register(as: converter.convert(label), with: flags)
+          }
+        } else {
+          wrapper.register(as: nil, with: flags)
+        }
+      }
+    }
+    if let reason = flags.parsingFailure() {
+      try command.fail(with: reason)
+    } else {
+      try command.run()
+    }
+  }
+}
+
+public class ArgumentNameConverter {
+  
+  public enum Strategy {
+    case camelcase
+    case lowercase
+    case separate(Character)
+  }
+  
+  public let strategy: Strategy
+  public let prefix: String
+  
+  public init(_ strategy: Strategy = .lowercase, prefix: String = "") {
+    self.strategy = strategy
+    self.prefix = prefix
+  }
+  
+  public func convert(_ name: String) -> String {
+    guard !name.isEmpty else {
+      return ""
+    }
+    switch self.strategy {
+      case .camelcase:
+        if prefix.isEmpty {
+          return name
+        } else {
+          return prefix + name.prefix(1).capitalized + name.dropFirst()
+        }
+      case .lowercase:
+        return (prefix + name).lowercased()
+      case .separate(let separator):
+        var index = name.startIndex
+        var separate = true
+        var res = ""
+        while index < name.endIndex {
+          let character = name[index]
+          if character.isUppercase {
+            if separate && !res.isEmpty {
+              res.append(separator)
+            }
+            let next = name.index(after: index)
+            separate = next < name.endIndex &&
+                       name[next].isUppercase &&
+                       name.index(after: next) < name.endIndex &&
+                       name[name.index(after: next)].isLowercase
+          } else {
+            separate = character != separator
+          }
+          res += character.lowercased()
+          index = name.index(after: index)
+        }
+        return res
+    }
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/CommandLineKit.h
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/CommandLineKit.h
@@ -1,0 +1,44 @@
+//
+//  CommandLineKit.h
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 08/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for CommandLineKit.
+FOUNDATION_EXPORT double CommandLineKitVersionNumber;
+
+//! Project version string for CommandLineKit.
+FOUNDATION_EXPORT const unsigned char CommandLineKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <CommandLineKit/PublicHeader.h>
+
+

--- a/External/swift-commandlinekit/Sources/CommandLineKit/ControlCharacters.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/ControlCharacters.swift
@@ -1,0 +1,64 @@
+//
+//  ControlCharacters.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014, Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+public enum ControlCharacters: UInt8 {
+  case Null = 0
+  case CtrlA = 1
+  case CtrlB = 2
+  case CtrlC = 3
+  case CtrlD = 4
+  case CtrlE = 5
+  case CtrlF = 6
+  case Bell = 7
+  case CtrlH = 8
+  case Tab = 9
+  case CtrlK = 11
+  case CtrlL = 12
+  case Enter = 13
+  case CtrlN = 14
+  case CtrlP = 16
+  case CtrlT = 20
+  case CtrlU = 21
+  case CtrlW = 23
+  case Esc = 27
+  case Backspace = 127
+  
+  var character: Character {
+    return Character(UnicodeScalar(Int(self.rawValue))!)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/ConvertibleFromString.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/ConvertibleFromString.swift
@@ -1,0 +1,125 @@
+//
+//  ConvertibleFromString.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 26/03/2017.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// Classes and structs implementing protocol `ConvertibleFromString` come with a default
+/// initializer which initializes the object/struct by parsing a string.
+///
+public protocol ConvertibleFromString {
+  init?(fromString: String)
+}
+
+extension ConvertibleFromString {
+  public static func from(string str: String) -> Self? {
+    return Self.init(fromString: str)
+  }
+}
+
+extension String: ConvertibleFromString {
+  public init?(fromString other: String) {
+    self.init(other)
+  }
+}
+
+extension Int: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension Int64: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension UInt: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension UInt64: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension Float: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension Double: ConvertibleFromString {
+  public init?(fromString str: String) {
+    self.init(str)
+  }
+}
+
+extension Bool: ConvertibleFromString {
+  public init?(fromString str: String) {
+    switch str.lowercased() {
+      case "true", "t", "yes", "y", "1":
+        self.init(true)
+      case "false", "f", "no", "n", "0":
+        self.init(false)
+      default:
+        return nil
+    }
+  }
+}
+
+extension RawRepresentable where RawValue: ConvertibleFromString {
+  public init?(fromString str: String) {
+    guard let value = RawValue.from(string: str) else {
+      return nil
+    }
+    self.init(rawValue: value)
+  }
+  
+  public static func from(string str: String) -> Self? {
+    return Self.init(fromString: str)
+  }
+}
+
+extension Optional: ConvertibleFromString where Wrapped: ConvertibleFromString {
+  public init?(fromString str: String) {
+    guard let value = Wrapped.from(string: str) else {
+      return nil
+    }
+    self.init(value)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/EditState.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/EditState.swift
@@ -1,0 +1,343 @@
+//
+//  EditState.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+internal class EditState {
+  let prompt: String
+  let promptProperties: TextProperties
+  let readProperties: TextProperties
+  let parenProperties: TextProperties
+  let maxCount: Int?
+  var buffer: String
+  var location: String.Index
+  
+  init(prompt: String,
+       maxCount: Int? = nil,
+       promptProperties: TextProperties = TextProperties.none,
+       readProperties: TextProperties = TextProperties.none,
+       parenProperties: TextProperties = TextProperties.none) {
+    self.prompt = prompt
+    self.promptProperties = promptProperties
+    self.readProperties = readProperties
+    self.parenProperties = parenProperties
+    self.maxCount = maxCount
+    self.buffer = ""
+    self.location = buffer.endIndex
+  }
+  
+  var cursorWidth: Int {
+    return self.cursorPosition + self.prompt.count
+  }
+  
+  var cursorPosition: Int {
+    return self.buffer.distance(from: self.buffer.startIndex, to: self.location)
+  }
+  
+  var cursorAtEnd: Bool {
+    return self.location == self.buffer.endIndex
+  }
+  
+  func insertCharacter(_ char: Character) -> Bool {
+    if let max = self.maxCount, self.buffer.count >= max {
+      return false
+    }
+    let origLoc = self.location
+    let origEnd = self.buffer.endIndex
+    self.buffer.insert(char, at: location)
+    self.location = self.buffer.index(after: location)
+    if origLoc == origEnd {
+      self.location = self.buffer.endIndex
+    }
+    return true
+  }
+  
+  func setBuffer(_ newBuffer: String, truncateIfNeeded: Bool = false) -> Bool {
+    if let max = self.maxCount, newBuffer.count >= max {
+      if truncateIfNeeded {
+        self.buffer = String(newBuffer.prefix(max))
+        return true
+      } else {
+        return false
+      }
+    } else {
+      self.buffer = newBuffer
+      return true
+    }
+  }
+  
+  func backspace() -> Bool {
+    if self.location != self.buffer.startIndex {
+      if self.location != self.buffer.startIndex {
+        self.location = self.buffer.index(before: self.location)
+      }
+      self.buffer.remove(at: self.location)
+      return true
+    } else {
+      return false
+    }
+  }
+  
+  func moveLeft() -> Bool {
+    if self.location == self.buffer.startIndex {
+      return false
+    } else {
+      self.location = self.buffer.index(before: self.location)
+      return true
+    }
+  }
+  
+  func moveRight() -> Bool {
+    if self.location == self.buffer.endIndex {
+      return false
+    } else {
+      self.location = self.buffer.index(after: self.location)
+      return true
+    }
+  }
+  
+  func moveHome() -> Bool {
+    if self.location == self.buffer.startIndex {
+      return false
+    } else {
+      self.location = self.buffer.startIndex
+      return true
+    }
+  }
+  
+  func moveEnd() -> Bool {
+    if self.location == self.buffer.endIndex {
+      return false
+    } else {
+      self.location = self.buffer.endIndex
+      return true
+    }
+  }
+  
+  func deleteCharacter() -> Bool {
+    if self.location >= self.buffer.endIndex || self.buffer.isEmpty {
+      return false
+    } else {
+      self.buffer.remove(at: self.location)
+      return true
+    }
+  }
+  
+  func eraseCharacterRight() -> Bool {
+    if self.buffer.count == 0 || self.location >= self.buffer.endIndex {
+      return false
+    } else {
+      self.buffer.remove(at: self.location)
+      if self.location > self.buffer.endIndex {
+        self.location = self.buffer.endIndex
+      }
+      return true
+    }
+  }
+  
+  func deletePreviousWord() -> Bool {
+    let oldLocation = self.location
+    // Go backwards to find the first non space character
+    while self.location > self.buffer.startIndex &&
+          self.buffer[self.buffer.index(before: self.location)] == " " {
+      self.location = self.buffer.index(before: self.location)
+    }
+    // Go backwards to find the next space character (start of the word)
+    while self.location > self.buffer.startIndex &&
+          self.buffer[self.buffer.index(before: self.location)] != " " {
+      self.location = self.buffer.index(before: self.location)
+    }
+    if self.buffer.distance(from: oldLocation, to: self.location) == 0 {
+      return false
+    } else {
+      self.buffer.removeSubrange(self.location..<oldLocation)
+      return true
+    }
+  }
+  
+  func moveToWordStart() -> Bool {
+    let oldLocation = self.location
+    // Go backwards to find the first non space character
+    while self.location > self.buffer.startIndex &&
+          self.buffer[self.buffer.index(before: self.location)] == " " {
+      self.location = self.buffer.index(before: self.location)
+    }
+    // Go backwards to find the next space character (start of the word)
+    while self.location > self.buffer.startIndex &&
+          self.buffer[self.buffer.index(before: self.location)] != " " {
+      self.location = self.buffer.index(before: self.location)
+    }
+    return self.buffer.distance(from: oldLocation, to: self.location) != 0
+  }
+  
+  func moveToWordEnd() -> Bool {
+    let oldLocation = self.location
+    // Go forward to find the first non space character
+    while self.location < self.buffer.endIndex && self.buffer[self.location] == " " {
+      self.location = self.buffer.index(after: self.location)
+    }
+    // Go forward to find the next space character (end of the word)
+    while self.location < self.buffer.endIndex && self.buffer[self.location] != " " {
+      self.location = self.buffer.index(after: self.location)
+    }
+    return self.buffer.distance(from: oldLocation, to: self.location) != 0
+  }
+  
+  func deleteToEndOfLine() -> Bool {
+    if self.location == self.buffer.endIndex || self.buffer.isEmpty {
+      return false
+    } else {
+      self.buffer.removeLast(self.buffer.count - self.cursorPosition)
+      return true
+    }
+  }
+  
+  func swapCharacterWithPrevious() -> Bool {
+    if buffer.count < 2 {
+      return false
+    } else if self.location == self.buffer.endIndex {
+      // Swap the two previous characters if at end index
+      let temp = self.buffer.remove(at: self.buffer.index(self.location, offsetBy: -2))
+      self.buffer.insert(temp, at: self.buffer.endIndex)
+      self.location = self.buffer.endIndex
+      return true
+    } else if self.location > self.buffer.startIndex {
+      // If the characters are in the middle of the string, swap character under cursor with
+      // previous, then move the cursor to the right
+      let temp = self.buffer.remove(at: self.buffer.index(before: self.location))
+      self.buffer.insert(temp, at: self.location)
+      if self.location < self.buffer.endIndex {
+        self.location = buffer.index(after: self.location)
+      }
+      return true
+    } else if self.location == self.buffer.startIndex {
+      // If the character is at the start of the string, swap the first two characters, then
+      // put the cursor after them
+      let temp = self.buffer.remove(at: self.location)
+      self.buffer.insert(temp, at: self.buffer.index(after: self.location))
+      if self.location < self.buffer.endIndex {
+        self.location = self.buffer.index(self.buffer.startIndex, offsetBy: 2)
+      }
+      return true
+    } else {
+      return false
+    }
+  }
+  
+  func requiresMatching() -> Bool {
+    guard self.location > self.buffer.startIndex, !self.parenProperties.isEmpty else {
+      return false
+    }
+    switch self.buffer[self.buffer.index(before: self.location)] {
+      case "(", ")", "[", "]", "{", "}":
+        return true
+      default:
+        return false
+    }
+  }
+  
+  func matchingParen() -> String.Index? {
+    guard self.location > self.buffer.startIndex, !self.parenProperties.isEmpty else {
+      return nil
+    }
+    var idx = self.buffer.index(before: self.location)
+    let this: Character = self.buffer[idx]
+    let other: Character
+    let forward: Bool
+    switch this {
+      case "(":
+        other = ")"
+        forward = true
+      case ")":
+        other = "("
+        forward = false
+      case "[":
+        other = "]"
+        forward = true
+      case "]":
+        other = "["
+        forward = false
+      case "{":
+        other = "}"
+        forward = true
+      case "}":
+        other = "{"
+        forward = false
+      default:
+        return nil
+    }
+    var open = 0
+    if forward {
+      idx = self.buffer.index(after: idx)
+      while idx < self.buffer.endIndex && (open > 0 || self.buffer[idx] != other) {
+        if self.buffer[idx] == this {
+          open += 1
+        } else if self.buffer[idx] == other {
+          open -= 1
+        }
+        idx = self.buffer.index(after: idx)
+      }
+      if idx < self.buffer.endIndex && open == 0 {
+        return idx
+      }
+    } else if idx > self.buffer.startIndex {
+      idx = self.buffer.index(before: idx)
+      while idx >= self.buffer.startIndex && (open > 0 || self.buffer[idx] != other) {
+        if self.buffer[idx] == this {
+          open += 1
+        } else if self.buffer[idx] == other {
+          open -= 1
+        }
+        guard idx > self.buffer.startIndex else {
+          return nil
+        }
+        idx = self.buffer.index(before: idx)
+      }
+      if idx >= self.buffer.startIndex && open == 0 {
+        return idx
+      }
+    }
+    return nil
+  }
+  
+  func withTemporaryState(_ body: () throws -> () ) throws {
+    let originalBuffer = self.buffer
+    let originalLocation = self.location
+    try body()
+    self.buffer = originalBuffer
+    self.location = originalLocation
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/Flag.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/Flag.swift
@@ -1,0 +1,374 @@
+//
+//  Flag.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 25/03/2017.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// A `Flag` object describes a command-line flag in terms of a short name, a long name, and
+/// a description. A short name is a character excluding '-', '=', ' ', '0', '1', '2', '3', '4',
+/// '5', '6', '7', '8', '9'. A long name is a non-empty string which does not contain whitespace
+/// and '=' characters. Also a single dash is not supported as a long name.
+///
+/// There are two different types of flags: options and arguments. An option is a boolean flag:
+/// it is either set or not set. An argument is a flag which comes with at least one argument.
+/// Method `isOption` can be used to distinguish between options and arguments.
+///
+public class Flag {
+  
+  /// The short name of the flag.
+  public let shortName: Character?
+  
+  /// The long name of the flag.
+  public let longName: String?
+  
+  /// The description of the flag.
+  public let helpDescription: String
+  
+  /// Is set to true if the flag was set on the command-line.
+  public fileprivate(set) var wasSet: Bool
+  
+  /// Initializes a flag
+  fileprivate init(shortName: Character?, longName: String?, description: String) {
+    assert(shortName != nil || longName != nil, "declared flag without short and long name")
+    if let name = shortName {
+      assert(name != "0" && name != "1" && name != "2" && name != "3" && name != "4" &&
+             name != "5" && name != "6" && name != "7" && name != "8" && name != "9" &&
+             name != "-" && name != "=" && name != " ",
+             "short flag name consists of illegal character")
+    }
+    if let name = longName {
+      assert(name.count != 0, "long flag name is empty for flag -\(shortName ?? "?")")
+      assert(name.contains { $0 == " " || $0 == "=" } == false,
+             "long flag name --\(name) contains illegal characters")
+      assert(name != "-", "long flag name --\(name) is a dash")
+    }
+    self.shortName = shortName
+    self.longName = longName
+    self.helpDescription = description
+    self.wasSet = false
+  }
+  
+  /// Returns true if this flag descriptor represents an option; i.e. a flag without argument.
+  public var isOption: Bool {
+    return false
+  }
+  
+  /// Parses the arguments of the flag starting `index` in argument array `args`.
+  public func parse(_ args: [String], at index: Int) throws -> Int {
+    self.wasSet = true
+    return index
+  }
+}
+
+///
+/// An `Option` is a flag that is either present or absent. If an option is present, the field
+/// `wasSet` is set to true. It is also possible to register a callback which gets invoked when
+/// the option was found during command-line parsing.
+///
+public final class Option: Flag {
+  private let notify: () throws -> Void
+  
+  /// Initializes an option with a parsing callback.
+  public init(shortName: Character?,
+              longName: String?,
+              description: String,
+              notify: @escaping () throws -> Void) {
+    self.notify = notify
+    super.init(shortName: shortName, longName: longName, description: description)
+  }
+  
+  /// Initializes an option without parsing callback.
+  public override init(shortName: Character?,
+                       longName: String?,
+                       description: String) {
+    self.notify = {}
+    super.init(shortName: shortName, longName: longName, description: description)
+  }
+  
+  /// Returns true
+  public override var isOption: Bool {
+    return true
+  }
+  
+  /// Parses an option.
+  public override func parse(_ args: [String], at index: Int) throws -> Int {
+    try self.notify()
+    self.wasSet = true
+    return index
+  }
+}
+
+///
+/// An `Argument` is a flag with parameters. Flags which allow multiple parameters need to
+/// get initialized such that `repeated` is set to true. For being able to handle
+/// arguments, the argument object needs to be provided a `handler` function which is
+/// responsible for parsing the string parameters and persisting the result.
+///
+public class Argument: Flag {
+  
+  /// Is this argument repeated?
+  public let repeated: Bool
+  
+  /// Handler for parsing and persisting argument values.
+  internal private(set) var handler: (String) throws -> Void
+  
+  /// A readable parameter name, used for documentation purposes.
+  public let paramIdent: String
+  
+  /// Initializes an argument from the given short name, long name, and description. `repeated`
+  /// needs to be set to true if the argument accepts multiple parameters. `handler` is used
+  /// for parsing and persisting parameters.
+  public init(shortName: Character?,
+              longName: String?,
+              paramIdent: String? = nil,
+              description: String,
+              repeated: Bool = false,
+              handler: @escaping (String) throws -> Void) {
+    self.repeated = repeated
+    self.handler = handler
+    self.paramIdent = paramIdent == nil ? (repeated ? "<value> ..." : "<value>") : paramIdent!
+    super.init(shortName: shortName, longName: longName, description: description)
+  }
+  
+  /// Initializes an argument of type `T` from the given short name, long name, and description.
+  /// `repeated` needs to be set to true if the argument accepts multiple parameters. `parse` is
+  /// used to parse the string parameter into a value of type `T`. `set` persists values of
+  /// type `T`.
+  public convenience init<T>(shortName: Character?,
+                             longName: String?,
+                             paramIdent: String? = nil,
+                             description: String,
+                             repeated: Bool = false,
+                             parse: @escaping (String) -> T?,
+                             set: @escaping (T) throws -> Void) {
+    self.init(shortName: shortName,
+              longName: longName,
+              paramIdent: paramIdent,
+              description: description,
+              repeated: repeated,
+              handler: { x in })
+    self.setHandler(parse: parse, set: set)
+  }
+  
+  /// Initializes an argument of type `T` from the given short name, long name, and description.
+  /// `repeated` needs to be set to true if the argument accepts multiple parameters. This
+  /// initializer handles subtypes of `ConvertibleFromString` which come with a default parsing
+  /// method. `set` persists values of type `T`.
+  public convenience init<T: ConvertibleFromString>(shortName: Character?,
+                                                    longName: String?,
+                                                    paramIdent: String? = nil,
+                                                    description: String,
+                                                    repeated: Bool = false,
+                                                    set: @escaping (T) throws -> Void) {
+    self.init(shortName: shortName,
+              longName: longName,
+              paramIdent: paramIdent,
+              description: description,
+              repeated: repeated,
+              handler: { x in })
+    self.setHandler(parse: T.from, set: set)
+  }
+  
+  /// Initializes an argument of type `T` from the given short name, long name, and description.
+  /// `repeated` needs to be set to true if the argument accepts multiple parameters. This
+  /// initializer handles subtypes of `ConvertibleFromString` which come with a default parsing
+  /// method. `set` persists values of type `T`.
+  public convenience init<T: RawRepresentable>(shortName: Character?,
+                                               longName: String?,
+                                               paramIdent: String? = nil,
+                                               description: String,
+                                               repeated: Bool = false,
+                                               set: @escaping (T) throws -> Void)
+                         where T.RawValue: ConvertibleFromString {
+    self.init(shortName: shortName,
+              longName: longName,
+              paramIdent: paramIdent,
+              description: description,
+              repeated: repeated,
+              handler: { x in })
+    self.setHandler(parse: T.from, set: set)
+  }
+  
+  /// Used internally to construct a handler from a `parse` and `set` function.
+  fileprivate func setHandler<T>(parse: @escaping (String) -> T?,
+                                 set: @escaping (T) throws -> Void) {
+    self.handler = { [unowned self] arg in
+      guard let value = parse(arg) else {
+        throw FlagError(.malformedValue(arg), self)
+      }
+      try set(value)
+    }
+  }
+  
+  /// Parses an option.
+  public override func parse(_ args: [String], at index: Int) throws -> Int {
+    var i = index
+    while i < args.count {
+      let arg = args[i]
+      if arg == Flags.terminator || arg.hasPrefix(Flags.longNamePrefix) {
+        guard self.repeated else {
+          throw FlagError(.missingValue, self)
+        }
+        return i
+      } else if arg.hasPrefix("-0") || arg.hasPrefix("-1") || arg.hasPrefix("-2") ||
+                arg.hasPrefix("-3") || arg.hasPrefix("-4") || arg.hasPrefix("-5") ||
+                arg.hasPrefix("-6") || arg.hasPrefix("-7") || arg.hasPrefix("-8") ||
+                arg.hasPrefix("-9") {
+        try self.handler(arg)
+        self.wasSet = true
+        i += 1
+        guard self.repeated else {
+          return i
+        }
+      } else if arg.hasPrefix("-") {
+        guard self.repeated else {
+          throw FlagError(.missingValue, self)
+        }
+        return i
+      } else {
+        try self.handler(arg)
+        self.wasSet = true
+        i += 1
+        guard self.repeated else {
+          return i
+        }
+      }
+    }
+    guard self.repeated else {
+      throw FlagError(.missingValue, self)
+    }
+    return i
+  }
+}
+
+///
+/// A `SingletonArgument` encapsulates a single, optional parameter value of type `T`. This
+/// class is most commonly used in command-line applications for handling arguments with a
+/// single parameter where the parameter extracted from the command-line is stored in the
+/// flag object itself.
+///
+public final class SingletonArgument<T>: Argument {
+  public var value: T?
+  
+  /// Initializes a singleton argument from the given short name, long name, and description.
+  /// `value` is a default value for the parameter. `parse` is used to parse strings into
+  /// values of type `T`.
+  public init(shortName: Character?,
+              longName: String?,
+              paramIdent: String? = nil,
+              description: String,
+              value: T? = nil,
+              parse: @escaping (String) -> T?) {
+    self.value = value
+    super.init(shortName: shortName,
+               longName: longName,
+               paramIdent: paramIdent,
+               description: description,
+               handler: { x in })
+    self.setHandler(parse: parse, set: { [unowned self] value in self.value = value })
+  }
+}
+
+extension SingletonArgument where T: ConvertibleFromString {
+  
+  /// Initializes a singleton argument from the given short name, long name, and description.
+  /// `value` is a default value for the parameter. The default parsing function is used.
+  public convenience init(shortName: Character?,
+                          longName: String?,
+                          paramIdent: String? = nil,
+                          description: String,
+                          value: T? = nil) {
+    self.init(shortName: shortName,
+              longName: longName,
+              paramIdent: paramIdent,
+              description: description,
+              value: value,
+              parse: T.from)
+  }
+}
+
+///
+/// A `RepeatedArgument` encapsulates a sequence of parameter values of type `T`. This
+/// class is most commonly used in command-line applications for handling arguments with
+/// potentially multiple parameter values where the parameters extracted from the command-line
+/// are stored in the flag object itself.
+///
+public final class RepeatedArgument<T>: Argument {
+  private let maxCount: Int
+  public var value: [T]
+  
+  /// Initializes a repeated argument from the given short name, long name, and description.
+  /// `maxCount` determines how many parameters are acceptable. `parse` is used to parse strings
+  /// into values of type `T`.
+  public init(shortName: Character?,
+              longName: String?,
+              paramIdent: String? = nil,
+              description: String,
+              maxCount: Int = Int.max,
+              parse: @escaping (String) -> T?) {
+    self.maxCount = maxCount
+    self.value = []
+    super.init(shortName: shortName,
+               longName: longName,
+               paramIdent: paramIdent,
+               description: description,
+               repeated: true,
+               handler: { x in })
+    self.setHandler(parse: parse, set: { [unowned self] value in
+      guard self.value.count < self.maxCount else {
+        throw FlagError(.tooManyValues(String(describing: self.value)), self)
+      }
+      self.value.append(value)
+    })
+  }
+}
+
+extension RepeatedArgument where T: ConvertibleFromString {
+  
+  /// Initializes a repeated argument from the given short name, long name, and description.
+  /// `maxCount` determines how many parameters are acceptable. The default parsing function
+  /// is used.
+  public convenience init(shortName: Character?,
+                          longName: String?,
+                          paramIdent: String? = nil,
+                          description: String,
+                          maxCount: Int = Int.max) {
+    self.init(shortName: shortName,
+              longName: longName,
+              paramIdent: paramIdent,
+              description: description,
+              maxCount: maxCount,
+              parse: T.from)
+  }
+}
+

--- a/External/swift-commandlinekit/Sources/CommandLineKit/FlagError.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/FlagError.swift
@@ -1,0 +1,64 @@
+//
+//  FlagError.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 25/03/2017.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// Enum `FlagError` defines all the errors potentially returned when parsing command-line
+/// arguments. Each flag error consists of a `kind` defining the type of the error as well
+/// as an optional `flag` referring to the flag to which the error belongs.
+///
+public struct FlagError: Error {
+  
+  /// The description of the error.
+  public enum Kind {
+    case unknownFlag(String)
+    case missingValue
+    case malformedValue(String)
+    case illegalFlagCombination(String)
+    case tooManyValues(String)
+  }
+  
+  /// The error kind.
+  public let kind: Kind
+  
+  /// The flag to which the error belongs. If `flag` is set to nil, the error is related to
+  /// parsing the command-line as a whole.
+  public let flag: Flag?
+  
+  /// Initializes a new flag error from an error kind and a corresponding flag.
+  public init(_ kind: Kind, _ flag: Flag? = nil) {
+    self.kind = kind
+    self.flag = flag
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/FlagWrapper.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/FlagWrapper.swift
@@ -1,0 +1,230 @@
+//
+//  FlagWrapper.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 20/08/2023.
+//  Copyright © 2023 Matthias Zenger. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+///
+/// Protocol implemented by all flag wrappers
+///
+public protocol FlagWrapper {
+  func register(as: String?, with: Flags)
+}
+
+/// Base class for all flag wrappers
+public class CommandFlag<Value, Flag> {
+  
+  public enum State<V, F> {
+    case config(shortName: Character?, longName: String?, description: String, value: V)
+    case flag(F)
+  }
+  
+  public var state: State<Value, Flag>
+  
+  public var projectedValue: Flag {
+    guard case .flag(let flag) = self.state else {
+      preconditionFailure("accessing flags accessor before initialization")
+    }
+    return flag
+  }
+  
+  public init(short: Character? = nil,
+              long: String? = nil,
+              description: String? = nil,
+              value: Value) {
+    self.state = .config(shortName: short,
+                         longName: long,
+                         description: description ?? "undocumented",
+                         value: value)
+  }
+}
+
+/// Inject the flags object into a command with the `@CommandFlags` property wrapper.
+@propertyWrapper
+public class CommandFlags: FlagWrapper {
+  private var flags: Flags?
+  
+  public var wrappedValue: Flags {
+    get {
+      guard let flags = self.flags else {
+        preconditionFailure("accessing flags accessor before initialization")
+      }
+      return flags
+    }
+  }
+  
+  public init() {
+    self.flags = nil
+  }
+  
+  public func register(as: String?, with flags: Flags) {
+    self.flags = flags
+  }
+}
+
+/// Declare an option flag
+@propertyWrapper
+public class CommandOption: CommandFlag<Bool, Option>, FlagWrapper {
+  
+  public var wrappedValue: Bool {
+    get {
+      guard case .flag(let flag) = self.state else {
+        preconditionFailure("accessing flags accessor before initialization")
+      }
+      return flag.wasSet
+    }
+  }
+  
+  public init(short: Character? = nil,
+              long: String? = nil,
+              description: String? = nil) {
+    super.init(short: short, long: long, description: description, value: false)
+  }
+  
+  public func register(as optName: String?, with flags: Flags) {
+    guard case .config(let short, let long, let descr, _) = self.state else {
+      preconditionFailure("initializing flag twice")
+    }
+    var longName: String? = long
+    if short == nil && long == nil {
+      longName = optName
+    }
+    let flag = flags.option(short, longName, description: descr)
+    self.state = .flag(flag)
+  }
+}
+
+/// Declare an argument flag
+@propertyWrapper
+public class CommandArgument<Value>: CommandFlag<Value, SingletonArgument<Value>>, FlagWrapper
+                                     where Value: ConvertibleFromString {
+  
+  public var wrappedValue: Value {
+    get {
+      guard case .flag(let flag) = self.state else {
+        preconditionFailure("accessing flags accessor before initialization")
+      }
+      return flag.value!
+    }
+  }
+  
+  public init<T>(short: Character? = nil,
+                 long: String? = nil,
+                 description: String? = nil) where Value == Optional<T> {
+    super.init(short: short, long: long, description: description, value: nil)
+  }
+  
+  public init(wrappedValue: Value,
+              short: Character? = nil,
+              long: String? = nil,
+              description: String? = nil) {
+    super.init(short: short, long: long, description: description, value: wrappedValue)
+  }
+  
+  public func register(as argName: String?, with flags: Flags) {
+    guard case .config(let short, let long, let descr, let value) = self.state else {
+      preconditionFailure("initializing flag twice")
+    }
+    var longName: String? = long
+    if short == nil && long == nil {
+      longName = argName
+    }
+    let flag = SingletonArgument(shortName: short,
+                                 longName: longName,
+                                 description: descr,
+                                 value: value)
+    flags.register(flag)
+    self.state = .flag(flag)
+  }
+}
+
+/// Declare a repeated argument flag
+@propertyWrapper
+public class CommandArguments<Value>: CommandFlag<Int, RepeatedArgument<Value>>, FlagWrapper
+                                      where Value: ConvertibleFromString {
+  
+  public var wrappedValue: [Value] {
+    get {
+      guard case .flag(let flag) = self.state else {
+        preconditionFailure("accessing flags accessor before initialization")
+      }
+      return flag.value
+    }
+  }
+  
+  public init(short: Character? = nil,
+              long: String? = nil,
+              description: String? = nil,
+              maxCount: Int = Int.max) {
+    super.init(short: short, long: long, description: description, value: maxCount)
+  }
+  
+  public func register(as argName: String?, with flags: Flags) {
+    guard case .config(let short, let long, let descr, let value) = self.state else {
+      preconditionFailure("initializing flag twice")
+    }
+    var longName: String? = long
+    if short == nil && long == nil {
+      longName = argName
+    }
+    let flag = RepeatedArgument<Value>(shortName: short,
+                                       longName: longName,
+                                       description: descr,
+                                       maxCount: value)
+    flags.register(flag)
+    self.state = .flag(flag)
+  }
+}
+
+/// Inject the remaining/unparsed parameters into a command with the `@CommandParameters`
+/// property wrapper.
+@propertyWrapper
+public class CommandParameters: FlagWrapper {
+  private var flags: Flags?
+  
+  public var wrappedValue: [String] {
+    get {
+      guard let flags = self.flags else {
+        preconditionFailure("accessing flags accessor before initialization")
+      }
+      return flags.parameters
+    }
+  }
+  
+  public init() {
+    self.flags = nil
+  }
+  
+  public func register(as: String?, with flags: Flags) {
+    self.flags = flags
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/Flags.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/Flags.swift
@@ -1,0 +1,383 @@
+//
+//  Flags.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 25/03/2017.
+//  Copyright © 2018-2023 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// Class `Flags` defines a builder for defining a set of supported command-line flags and
+/// for extracting and parsing them from a given command-line. `Flags` objects are used in three
+/// subsequent stages:
+///    1. A new flags object is created for a command-line (represented as an array of strings),
+///    2. The flags are defined via `register`, `option`, `argument`, and `arguments`, and
+///    3. The flags are parsed by calling `parse`.
+///
+public class Flags {
+  
+  /// Terminator for command-line parsing. All following arguments are considered global
+  /// parameters.
+  internal static let terminator = "---"
+  
+  /// Prefix for long flag names (consisting of multiple characters).
+  internal static let longNamePrefix = "--"
+  
+  /// Prefix for short flag names (consisting of a single character).
+  internal static let shortNamePrefix = "-"
+  
+  /// The registered flags.
+  public private(set) var descriptors: [Flag] = []
+  
+  /// Internal map from short name to flag.
+  private var shortNameMap: [Character : Flag] = [:]
+  
+  /// Internal map from long name to flag.
+  private var longNameMap: [String : Flag] = [:]
+  
+  /// The name of the command-line tool.
+  public let toolName: String
+  
+  /// The command-line arguments.
+  public let arguments: [String]
+  
+  /// Sequence of global parameters not associated with a flag.
+  public private(set) var parameters: [String] = []
+  
+  /// Initializes a flag set using the default command-line arguments.
+  public init() {
+    if let toolPath = CommandLine.arguments.first {
+      self.toolName = URL(fileURLWithPath: toolPath).lastPathComponent
+    } else {
+      self.toolName = "<unknown>"
+    }
+    var args = CommandLine.arguments
+    args.removeFirst()
+    self.arguments = args
+  }
+  
+  /// Initializes a flag set from the given command-line.
+  public init(toolName: String = "<unknown>", arguments: [String]) {
+    self.toolName = toolName
+    self.arguments = arguments
+  }
+  
+  /// Parses the command-line given the previously defined flags.
+  public func parse() throws {
+    var i = 0
+    while i < self.arguments.count {
+      let arg = self.arguments[i]
+      i += 1
+      if arg == Flags.terminator {
+        while i < self.arguments.count {
+          self.parameters.append(self.arguments[i])
+          i += 1
+        }
+      } else if arg.hasPrefix(Flags.longNamePrefix) {
+        let len = Flags.longNamePrefix.count
+        // let longName = arg.substring(from: arg.index(arg.startIndex, offsetBy: len))
+        let longName = String(arg[arg.index(arg.startIndex, offsetBy: len)...])
+        guard let flag = self.longNameMap[longName] else {
+          throw FlagError(.unknownFlag(arg))
+        }
+        i = try flag.parse(self.arguments, at: i)
+      } else if arg.hasPrefix(Flags.shortNamePrefix) {
+        let len = Flags.shortNamePrefix.count
+        var index = arg.index(arg.startIndex, offsetBy: len)
+        if index == arg.endIndex {
+          self.parameters.append(arg)
+        } else {
+          while index < arg.endIndex {
+            guard let flag = self.shortNameMap[arg[index]] else {
+              throw FlagError(.unknownFlag(String(arg[index])))
+            }
+            index = arg.index(after: index)
+            if index == arg.endIndex {
+              i = try flag.parse(self.arguments, at: i)
+            } else if flag.isOption {
+              let j = try flag.parse(self.arguments, at: i)
+              assert(i == j, "malformed option")
+            } else {
+              throw FlagError(.illegalFlagCombination(arg))
+            }
+          }
+        }
+      } else {
+        self.parameters.append(arg)
+      }
+    }
+  }
+  
+  /// Parses the command-line and returns a readable error message if parsing did not succeed.
+  public func parsingFailure() -> String? {
+    do {
+      try self.parse()
+      return nil
+    } catch let error as FlagError {
+      let flagname = error.flag?.longName ?? error.flag?.shortName?.description
+      var message = error.flag == nil ? "error parsing flags: "
+                                      : "error parsing flag `\(flagname!)`: "
+      switch error.kind {
+        case .unknownFlag(let str):
+          message += "unknown flag `\(str)`"
+        case .missingValue:
+          message += "missing value"
+        case .malformedValue(let str):
+          message += "malformed value `\(str)`"
+        case .illegalFlagCombination(let str):
+          message += "illegal flag combination with `\(str)`"
+        case .tooManyValues(let str):
+          message += "too many values from `\(str)`"
+      }
+      return message
+    } catch {
+      return "unknown error while parsing flags"
+    }
+  }
+  
+  /// Registers a new custom flag.
+  public func register(_ flag: Flag) {
+    if let shortName = flag.shortName {
+      assert(self.shortNameMap[shortName] == nil,
+             "ambiguous definition of flag \(Flags.shortNamePrefix)\(shortName)")
+      self.shortNameMap[shortName] = flag
+    }
+    if let longName = flag.longName {
+      assert(self.longNameMap[longName] == nil,
+             "ambiguous definition of flag \(Flags.longNamePrefix)\(longName)")
+      self.longNameMap[longName] = flag
+    }
+    self.descriptors.append(flag)
+  }
+  
+  /// Registers a new option for the given short flag name, long flag name, and description.
+  public func option(_ shortName: Character?,
+                     _ longName: String? = nil,
+                     description: String) -> Option {
+    let flag = Option(shortName: shortName,
+                      longName: longName,
+                      description: description)
+    self.register(flag)
+    return flag
+  }
+  
+  /// Registers a new argument of type `T` for the given short flag name, long flag name, and
+  /// description. `repeated` needs to be set to true if the argument is allowed to have multiple
+  /// parameters. Function `set` is used to persist the parsed values of type `T`.
+  public func argument<T: ConvertibleFromString>(_ shortName: Character?,
+                                                 _ longName: String? = nil,
+                                                 paramIdent: String? = nil,
+                                                 description: String,
+                                                 repeated: Bool = false,
+                                                 set: @escaping (T) -> Void) -> Argument {
+    let flag = Argument(shortName: shortName,
+                        longName: longName,
+                        paramIdent: paramIdent,
+                        description: description,
+                        repeated: repeated,
+                        set: set)
+    self.register(flag)
+    return flag
+  }
+  
+  /// Registers a new singleton argument of type `T` for the given short flag name, long flag
+  /// name, and description. `value` defines an optional default parameter value.
+  public func argument<T: ConvertibleFromString>(_ shortName: Character?,
+                                                 _ longName: String? = nil,
+                                                 paramIdent: String? = nil,
+                                                 description: String,
+                                                 value: T? = nil) -> SingletonArgument<T> {
+    let flag = SingletonArgument<T>(shortName: shortName,
+                                    longName: longName,
+                                    paramIdent: paramIdent,
+                                    description: description,
+                                    value: value)
+    self.register(flag)
+    return flag
+  }
+  
+  /// Registers a new repeated argument of type `T` for the given short flag name, long flag
+  /// name, and description. `maxCount` determines how many parameters are accepted at most.
+  public func arguments<T: ConvertibleFromString>(_ shortName: Character?,
+                                                  _ longName: String? = nil,
+                                                  paramIdent: String? = nil,
+                                                  description: String,
+                                                  maxCount: Int = Int.max) -> RepeatedArgument<T> {
+    let flag = RepeatedArgument<T>(shortName: shortName,
+                                   longName: longName,
+                                   paramIdent: paramIdent,
+                                   description: description,
+                                   maxCount: maxCount)
+    self.register(flag)
+    return flag
+  }
+  
+  /// Returns a human readable usage description text that can be printed for helping users
+  /// better understand the available flags.
+  public func usageDescription(usageName: String = "USAGE:",
+                               synopsis: String = "[<option> ...] [--] [<arg> ...]",
+                               usageStyle: TextProperties = TextProperties.none,
+                               optionsName: String = "OPTIONS:",
+                               flagStyle: TextProperties = TextProperties.none,
+                               indent: String = "  ") -> String {
+    var buffer = usageStyle.apply(to: "\(usageName) \(self.toolName) \(synopsis)")
+    buffer += "\n\(optionsName)\n"
+    for flag in self.descriptors {
+      var flagStr = ""
+      if let shortName = flag.shortName {
+        flagStr += "-\(shortName)"
+      }
+      if let longName = flag.longName {
+        if flag.shortName != nil {
+          flagStr += ", "
+        }
+        flagStr += "--\(longName)"
+      }
+      if let argument = flag as? Argument {
+        flagStr += " \(argument.paramIdent)"
+      }
+      buffer += indent + flagStyle.apply(to: flagStr)
+      buffer += "\n\(indent)\(indent)\(indent)\(flag.helpDescription)\n"
+    }
+    return buffer
+  }
+}
+
+///
+/// This extension defines a few convenience methods for registering arguments of type `String`,
+/// `Int`, `Double`, and enumerations whose raw type implements the `ConvertibleFromString`
+/// protocol.
+///
+extension Flags {
+  
+  public func string(_ shortName: Character?,
+                     _ longName: String? = nil,
+                     paramIdent: String? = nil,
+                     description: String,
+                     value: String? = nil) -> SingletonArgument<String> {
+    return self.argument(shortName,
+                         longName,
+                         paramIdent: paramIdent,
+                         description: description,
+                         value: value)
+  }
+  
+  public func `enum`<T: RawRepresentable>(_ shortName: Character?,
+                                          _ longName: String? = nil,
+                                          paramIdent: String? = nil,
+                                          description: String,
+                                          value: T? = nil) -> SingletonArgument<T>
+                    where T.RawValue: ConvertibleFromString {
+    let flag = SingletonArgument<T>(shortName: shortName,
+                                    longName: longName,
+                                    paramIdent: paramIdent,
+                                    description: description,
+                                    value: value,
+                                    parse: T.from)
+    self.register(flag)
+    return flag
+  }
+  
+  public func int(_ shortName: Character?,
+                  _ longName: String? = nil,
+                  paramIdent: String? = nil,
+                  description: String,
+                  value: Int? = nil) -> SingletonArgument<Int> {
+    return self.argument(shortName,
+                         longName,
+                         paramIdent: paramIdent,
+                         description: description,
+                         value: value)
+  }
+  
+  public func double(_ shortName: Character?,
+                     _ longName: String? = nil,
+                     paramIdent: String? = nil,
+                     description: String,
+                     value: Double? = nil) -> SingletonArgument<Double> {
+    return self.argument(shortName,
+                         longName,
+                         paramIdent: paramIdent,
+                         description: description,
+                         value: value)
+  }
+  
+  public func strings(_ shortName: Character?,
+                      _ longName: String? = nil,
+                      paramIdent: String? = nil,
+                      description: String,
+                      maxCount: Int = Int.max) -> RepeatedArgument<String> {
+    return self.arguments(shortName,
+                          longName,
+                          paramIdent: paramIdent,
+                          description: description,
+                          maxCount: maxCount)
+  }
+  
+  public func enums<T: RawRepresentable>(_ shortName: Character?,
+                                         _ longName: String? = nil,
+                                         paramIdent: String? = nil,
+                                         description: String,
+                                         maxCount: Int = Int.max) -> RepeatedArgument<T>
+                   where T.RawValue: ConvertibleFromString {
+      let flag = RepeatedArgument<T>(shortName: shortName,
+                                     longName: longName,
+                                     paramIdent: paramIdent,
+                                     description: description,
+                                     maxCount: maxCount,
+                                     parse: T.from)
+      self.register(flag)
+      return flag
+  }
+  
+  public func ints(_ shortName: Character?,
+                   _ longName: String? = nil,
+                   paramIdent: String? = nil,
+                   description: String,
+                   maxCount: Int = Int.max) -> RepeatedArgument<Int> {
+    return self.arguments(shortName,
+                          longName,
+                          paramIdent: paramIdent,
+                          description: description,
+                          maxCount: maxCount)
+  }
+  
+  public func doubles(_ shortName: Character?,
+                      _ longName: String? = nil,
+                      paramIdent: String? = nil,
+                      description: String,
+                      maxCount: Int = Int.max) -> RepeatedArgument<Double> {
+    return self.arguments(shortName,
+                          longName,
+                          paramIdent: paramIdent,
+                          description: description,
+                          maxCount: maxCount)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/Info.plist
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.3.4</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2018-2021 Google LLC</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/External/swift-commandlinekit/Sources/CommandLineKit/LineReader.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/LineReader.swift
@@ -1,0 +1,715 @@
+//
+//  LineReader.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2021 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+
+public class LineReader {
+
+  /// Does this terminal support this line reader?
+  public let termSupported: Bool
+
+  /// Terminal type
+  public let currentTerm: String
+
+  /// Does the terminal support colors?
+  public let fullColorSupport: Bool
+
+  /// If false (the default) any edits by the user to a line in the history will be discarded
+  /// if the user moves forward or back in the history without pressing Enter. If true, all
+  /// history edits will be preserved.
+  public var preserveHistoryEdits = false
+
+  /// The history of previous line reads
+  private var history: LineReaderHistory
+
+  /// Temporary line read buffer to handle browsing of histories
+  private var tempBuf: String?
+
+  /// A callback for handling line completions
+  private var completionCallback: ((String) -> [String])?
+
+  /// A callback for handling hints
+  private var hintsCallback: ((String) -> (String, TextProperties)?)?
+
+  /// A POSIX file handle for the input
+  private let inputFile: Int32
+
+  /// A POSIX file handle for the output
+  private let outputFile: Int32
+
+  /// Initializer
+  public init?(inputFile: Int32 = STDIN_FILENO,
+               outputFile: Int32 = STDOUT_FILENO,
+               completionCallback: ((String) -> [String])? = nil,
+               hintsCallback: ((String) -> (String, TextProperties)?)? = nil) {
+    self.inputFile = inputFile
+    self.outputFile = outputFile
+    self.currentTerm = Terminal.current
+    if isatty(inputFile) != 1 {
+      return nil
+    } else {
+      self.termSupported = LineReader.supportedBy(terminal: self.currentTerm)
+    }
+    self.fullColorSupport = Terminal.fullColorSupport(terminal: self.currentTerm)
+    self.history = LineReaderHistory()
+    self.completionCallback = completionCallback
+    self.hintsCallback = hintsCallback
+  }
+
+  public static var supportedByTerminal: Bool {
+    return LineReader.supportedBy(terminal: Terminal.current)
+  }
+
+  public static func supportedBy(terminal: String) -> Bool {
+    #if os(macOS)
+    if let xpcServiceName = ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"],
+       xpcServiceName.localizedCaseInsensitiveContains("com.apple.dt.xcode") {
+      return false
+    }
+    #endif
+    switch terminal {
+      case "", "xcode", "dumb", "cons25", "emacs":
+        return false
+      default:
+        return true
+    }
+  }
+
+  /// Adds a string to the history buffer.
+  public func addHistory(_ item: String) {
+    self.history.add(item)
+  }
+
+  /// Adds a callback for tab completion. The callback is taking the current text and returning
+  /// an array of Strings containing possible completions.
+  public func setCompletionCallback(_ callback: @escaping (String) -> [String]) {
+    self.completionCallback = callback
+  }
+
+  /// Adds a callback for hints as you type. The callback is taking the current text and
+  /// optionally returning the hint and a tuple of RGB colours for the hint text.
+  public func setHintsCallback(_ callback: @escaping (String) -> (String, TextProperties)?) {
+    self.hintsCallback = callback
+  }
+
+  /// Loads history from a file and appends it to the current history buffer. This method can
+  /// throw an error if the file cannot be found or loaded.
+  public func loadHistory(fromFile path: String) throws {
+    try self.history.load(fromFile: path)
+  }
+
+  /// Saves history to a file. This method can throw an error if the file cannot be written to.
+  public func saveHistory(toFile path: String) throws {
+    try self.history.save(toFile: path)
+  }
+
+  /// Sets the maximum amount of items to keep in history. If this limit is reached, the oldest
+  /// item is discarded when a new item is added. Setting the maximum length of history to 0
+  /// (the default) will keep unlimited items in history.
+  public func setHistoryMaxLength(_ historyMaxLength: UInt) {
+    self.history.maxLength = historyMaxLength
+  }
+
+  /// Clears the screen. This method can throw an error if the terminal cannot be written to.
+  public func clearScreen() throws {
+    if self.termSupported {
+      try self.output(text: AnsiCodes.homeCursor)
+      try self.output(text: AnsiCodes.clearScreen)
+    }
+  }
+
+  /// The main function of LineReader. This method shows a prompt to the user at the beginning
+  /// of the line and reads the input from the user, returning it as a string. The method can
+  /// throw an error if the terminal cannot be written to.
+  public func readLine(prompt: String,
+                       maxCount: Int? = nil,
+                       strippingNewline: Bool = true,
+                       promptProperties: TextProperties = TextProperties.none,
+                       readProperties: TextProperties = TextProperties.none,
+                       parenProperties: TextProperties = TextProperties.none) throws -> String {
+    tempBuf = nil
+    if self.termSupported {
+      return try self.readLineSupported(prompt: prompt,
+                                        maxCount: maxCount,
+                                        strippingNewline: strippingNewline,
+                                        promptProperties: promptProperties,
+                                        readProperties: readProperties,
+                                        parenProperties: parenProperties)
+    } else {
+      return try self.readLineUnsupported(prompt: prompt,
+                                          maxCount: maxCount,
+                                          strippingNewline: strippingNewline)
+    }
+  }
+
+  private func readLineUnsupported(prompt: String,
+                                   maxCount: Int?,
+                                   strippingNewline: Bool) throws -> String {
+    Swift.print(prompt, terminator: "")
+    if let line = Swift.readLine(strippingNewline: strippingNewline) {
+      return maxCount != nil ? String(line.prefix(maxCount!)) : line
+    } else {
+      throw LineReaderError.EOF
+    }
+  }
+
+  private func readLineSupported(prompt: String,
+                                 maxCount: Int?,
+                                 strippingNewline: Bool,
+                                 promptProperties: TextProperties,
+                                 readProperties: TextProperties,
+                                 parenProperties: TextProperties) throws -> String {
+    var line: String = ""
+    if fileno(stdout) == self.outputFile {
+      fflush(stdout)
+    }
+    try self.withRawMode {
+      if let col = self.cursorColumn, col > 1 {
+        try self.output(text: "\n" + AnsiCodes.setCursorColumn(0))
+      }
+      try self.output(text: promptProperties.apply(to: prompt))
+      let editState = EditState(prompt: prompt,
+                                maxCount: maxCount,
+                                promptProperties: promptProperties,
+                                readProperties: readProperties,
+                                parenProperties: parenProperties)
+      while true {
+        guard var char = self.readByte() else {
+          return
+        }
+        if char == ControlCharacters.Tab.rawValue && self.completionCallback != nil,
+           let completionChar = try self.completeLine(editState: editState) {
+          char = completionChar
+        }
+        if let rv = try self.handleCharacter(char, editState: editState) {
+          if editState.moveEnd() {
+            try self.updateCursorPos(editState: editState)
+          }
+          // It's unclear to me why it's necessary to set the cursor to column 0
+          try self.output(text: "\n" + AnsiCodes.setCursorColumn(0))
+          line = rv
+          return
+        }
+      }
+    }
+    return strippingNewline ? line : line + "\n"
+  }
+
+  private func completeLine(editState: EditState) throws -> UInt8? {
+    guard let completionCallback = self.completionCallback else {
+      return nil
+    }
+    let completions = completionCallback(editState.buffer)
+    guard completions.count > 0 else {
+      self.ringBell()
+      return nil
+    }
+    // Loop to handle inputs
+    var completionIndex = 0
+    while true {
+      if completionIndex < completions.count {
+        try editState.withTemporaryState {
+          try self.setBuffer(editState: editState, new: completions[completionIndex])
+        }
+      } else {
+        try refreshLine(editState: editState)
+      }
+      guard let char = self.readByte() else {
+        return nil
+      }
+      switch char {
+        case ControlCharacters.Tab.rawValue:
+          // Move to next completion
+          completionIndex = (completionIndex + 1) % (completions.count + 1)
+          if completionIndex == completions.count {
+            self.ringBell()
+          }
+        case ControlCharacters.Esc.rawValue:
+          // Show the original buffer
+          if completionIndex < completions.count {
+            try refreshLine(editState: editState)
+          }
+          return char
+        default:
+          // Update the buffer and return
+          if completionIndex < completions.count {
+            try self.setBuffer(editState: editState, new: completions[completionIndex])
+          }
+          return char
+      }
+    }
+  }
+
+  private func handleCharacter(_ ch: UInt8, editState: EditState) throws -> String? {
+    switch ch {
+      case ControlCharacters.Enter.rawValue:
+        try refreshLine(editState: editState, decorate: false)
+        return editState.buffer
+      case ControlCharacters.CtrlA.rawValue:
+        try self.moveHome(editState: editState)
+      case ControlCharacters.CtrlE.rawValue:
+        try self.moveEnd(editState: editState)
+      case ControlCharacters.CtrlB.rawValue:
+        try self.moveLeft(editState: editState)
+      case ControlCharacters.CtrlC.rawValue:
+        // Throw an error so that CTRL+C can be handled by the caller
+        throw LineReaderError.CTRLC
+      case ControlCharacters.CtrlD.rawValue:
+        // If there is a character at the right of the cursor, remove it
+        if editState.eraseCharacterRight() {
+          try self.refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+      case ControlCharacters.CtrlP.rawValue:
+        // Previous history item
+        try self.moveHistory(editState: editState, direction: .previous)
+      case ControlCharacters.CtrlN.rawValue:
+        // Next history item
+        try self.moveHistory(editState: editState, direction: .next)
+      case ControlCharacters.CtrlL.rawValue:
+        // Clear screen
+        try self.clearScreen()
+        try self.refreshLine(editState: editState)
+      case ControlCharacters.CtrlT.rawValue:
+        if editState.swapCharacterWithPrevious() {
+          try refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+      case ControlCharacters.CtrlU.rawValue:
+        // Delete whole line
+        try self.setBuffer(editState: editState, new: "")
+      case ControlCharacters.CtrlK.rawValue:
+        // Delete to the end of the line
+        if editState.deleteToEndOfLine() {
+          try self.refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+      case ControlCharacters.CtrlW.rawValue:
+        // Delete previous word
+        if editState.deletePreviousWord() {
+          try self.refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+      case ControlCharacters.Backspace.rawValue:
+        // Delete character
+        if editState.backspace() {
+          try self.refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+      case ControlCharacters.Esc.rawValue:
+        try self.handleEscapeCode(editState: editState)
+      default:
+        // Read unicode character and insert it at the cursor position using UTF8 encoding
+        var scalar = UInt32(ch)
+        if ch >> 7 == 0 {
+          // done
+        } else if ch >> 5 == 0x6 {
+          let ch2 = self.forceReadByte()
+          scalar = (UInt32(ch & 0x1F) << 6) | UInt32(ch2 & 0x3F)
+        } else if ch >> 4 == 0xE {
+          let ch2 = self.forceReadByte()
+          let ch3 = self.forceReadByte()
+          scalar = (UInt32(ch & 0xF) << 12) | (UInt32(ch2 & 0x3F) << 6) | UInt32(ch3 & 0x3F)
+        } else if ch >> 3 == 0x1E {
+          let ch2 = self.forceReadByte()
+          let ch3 = self.forceReadByte()
+          let ch4 = self.forceReadByte()
+          scalar = (UInt32(ch & 0x7) << 18) |
+                   (UInt32(ch2 & 0x3F) << 12) |
+                   (UInt32(ch3 & 0x3F) << 6) |
+                   UInt32(ch4 & 0x3F)
+        }
+        let char = Character(UnicodeScalar(scalar) ?? UnicodeScalar(" "))
+        if editState.insertCharacter(char) {
+          try refreshLine(editState: editState)
+        } else {
+          self.ringBell()
+        }
+        if self.bytesAvailable > 0 {
+          self.ringBell()
+        }
+    }
+    return nil
+  }
+
+  private func handleEscapeCode(editState: EditState) throws {
+    let fst = self.readCharacter()
+    switch fst {
+      case "[":
+        let snd = self.readCharacter()
+        switch snd {
+          // Handle multi-byte sequence ^[[0...
+          case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+            let trd = self.readCharacter()
+            switch trd {
+              case "~":
+                switch snd {
+                  case "1", "7":
+                    try self.moveHome(editState: editState)
+                  case "3":
+                    try self.deleteCharacter(editState: editState)
+                  case "4":
+                    try self.moveEnd(editState: editState)
+                  default:
+                    break
+                }
+              case ";":
+                let fot = self.readCharacter()
+                let fth = self.readCharacter()
+                // Shift
+                if fot == "2" {
+                  switch fth {
+                    case "C":
+                      try self.moveRight(editState: editState)
+                    case "D":
+                      try self.moveLeft(editState: editState)
+                    default:
+                      break
+                  }
+                }
+                break
+              case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+                _ = self.readCharacter()
+                // ignore these codes for now
+                break
+              default:
+                break
+            }
+          // ^[...
+          case "A":
+            try self.moveHistory(editState: editState, direction: .previous)
+          case "B":
+            try self.moveHistory(editState: editState, direction: .next)
+          case "C":
+            try self.moveRight(editState: editState)
+          case "D":
+            try self.moveLeft(editState: editState)
+          case "H":
+            try self.moveHome(editState: editState)
+          case "F":
+            try self.moveEnd(editState: editState)
+          default:
+            break
+        }
+      case "O":
+        // ^[O...
+        let snd = self.readCharacter()
+        switch snd {
+          case "H":
+            try self.moveHome(editState: editState)
+          case "F":
+            try self.moveEnd(editState: editState)
+          case "P":
+            // F1
+            break
+          case "Q":
+            // F2
+            break
+          case "R":
+            // F3
+            break
+          case "S":
+            // F4
+            break
+          default:
+            break
+        }
+      case "b":
+        // Alt+Left
+        try self.moveToWordStart(editState: editState)
+      case "f":
+        // Alt+Right
+        try self.moveToWordEnd(editState: editState)
+      default:
+        break
+    }
+  }
+
+  private var cursorColumn: Int? {
+    do {
+      try self.output(text: AnsiCodes.cursorLocation)
+    } catch {
+      return nil
+    }
+    var buf = [UInt8]()
+    while true {
+      if let c = self.readByte() {
+        if c == 82 { // "R"
+          break
+        }
+        buf.append(c)
+      } else {
+        return nil
+      }
+    }
+    guard buf[0] == 0x1B && buf[1] == 0x5B,
+          let cursor = String(bytes: buf[2..<buf.count], encoding: .utf8)?.split(separator: ";"),
+          cursor.count == 2 else {
+      return nil
+    }
+    return Int(String(cursor[1]))
+  }
+
+  private var numColumns: Int {
+    var winSize = winsize()
+    if ioctl(1, UInt(TIOCGWINSZ), &winSize) == -1 || winSize.ws_col == 0 {
+      return 80
+    } else {
+      return Int(winSize.ws_col)
+    }
+  }
+
+  /// This constant is unfortunately not defined right now for usage in Swift; it is specific
+  /// to macOS. Thus, this code is not portable!
+  private static let FIONREAD: UInt = 0x4004667f
+
+  private var bytesAvailable: Int {
+    var available: Int = 0
+    guard ioctl(self.inputFile, LineReader.FIONREAD, &available) >= 0 else {
+      return 0
+    }
+    return available
+  }
+
+  private func updateCursorPos(editState: EditState) throws {
+    if editState.requiresMatching() {
+      try self.refreshLine(editState: editState)
+    } else {
+      let cursorWidth = editState.cursorWidth
+      let numColumns = self.numColumns
+      let cursorRows = cursorWidth / numColumns
+      let cursorCols = cursorWidth % numColumns
+      var commandBuf = AnsiCodes.beginningOfLine
+      commandBuf += AnsiCodes.cursorDown(cursorRows)
+      commandBuf += AnsiCodes.cursorForward(cursorCols)
+      try self.output(text: commandBuf)
+    }
+  }
+
+  private func refreshLine(editState: EditState, decorate: Bool = true) throws {
+    let cursorWidth = editState.cursorWidth
+    let numColumns = self.numColumns
+    let cursorRows = cursorWidth / numColumns
+    let cursorCols = cursorWidth % numColumns
+    var commandBuf = AnsiCodes.beginningOfLine +
+                     editState.promptProperties.apply(to: editState.prompt)
+    if decorate, let idx = editState.matchingParen() {
+      var fst = editState.buffer.index(before: editState.location)
+      var snd = idx
+      if fst > snd {
+        snd = fst
+        fst = idx
+      }
+      let one = String(editState.buffer.prefix(upTo: fst))
+      let two = String(editState.buffer[editState.buffer.index(after: fst)..<snd])
+      let three = String(editState.buffer.suffix(from: editState.buffer.index(after: snd)))
+      let highlightProperties = editState.readProperties.with(editState.parenProperties)
+      commandBuf += editState.readProperties.apply(to: one)
+      commandBuf += highlightProperties.apply(to: String(editState.buffer[fst]))
+      commandBuf += editState.readProperties.apply(to: two)
+      commandBuf += highlightProperties.apply(to: String(editState.buffer[snd]))
+      commandBuf += editState.readProperties.apply(to: three)
+    } else {
+      commandBuf += editState.readProperties.apply(to: editState.buffer)
+    }
+    let hints = decorate ? try self.refreshHints(editState: editState) : ""
+    commandBuf += hints.isEmpty ? " " : hints
+    commandBuf += AnsiCodes.clearCursorToBottom +
+                  AnsiCodes.beginningOfLine +
+                  AnsiCodes.cursorDown(cursorRows) +
+                  AnsiCodes.cursorForward(cursorCols)
+    try self.output(text: commandBuf)
+  }
+
+  private func readByte() -> UInt8? {
+    var input: UInt8 = 0
+    if read(self.inputFile, &input, 1) == 0 {
+      return nil
+    }
+    return input
+  }
+
+  private func forceReadByte() -> UInt8 {
+    var input: UInt8 = 0
+    _ = read(self.inputFile, &input, 1)
+    return input
+  }
+
+  private func readCharacter() -> Character? {
+    var input: UInt8 = 0
+    _ = read(self.inputFile, &input, 1)
+    return Character(UnicodeScalar(input))
+  }
+
+  private func ringBell() {
+    do {
+      try self.output(character: ControlCharacters.Bell.character)
+    } catch {
+      // ignore failure
+    }
+  }
+
+  private func output(character: ControlCharacters) throws {
+    try self.output(character: character.character)
+  }
+
+  private func output(character: Character) throws {
+    try self.output(text: String(character))
+  }
+
+  private func output(text: String) throws {
+    if write(self.outputFile, text, text.utf8.count) == -1 {
+      throw LineReaderError.generalError("Unable to write to output")
+    }
+  }
+
+  private func setBuffer(editState: EditState, new buffer: String) throws {
+    if editState.setBuffer(buffer) {
+      _ = editState.moveEnd()
+      try self.refreshLine(editState: editState)
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func moveLeft(editState: EditState) throws {
+    if editState.moveLeft() {
+      try self.updateCursorPos(editState: editState)
+    }
+  }
+
+  private func moveRight(editState: EditState) throws {
+    if editState.moveRight() {
+      try self.updateCursorPos(editState: editState)
+    }
+  }
+
+  private func moveHome(editState: EditState) throws {
+    if editState.moveHome() {
+      try self.updateCursorPos(editState: editState)
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func moveEnd(editState: EditState) throws {
+    if editState.moveEnd() {
+      try self.updateCursorPos(editState: editState)
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func moveToWordStart(editState: EditState) throws {
+    if editState.moveToWordStart() {
+      try self.updateCursorPos(editState: editState)
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func moveToWordEnd(editState: EditState) throws {
+    if editState.moveToWordEnd() {
+      try self.updateCursorPos(editState: editState)
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func deleteCharacter(editState: EditState) throws {
+    if editState.deleteCharacter() {
+      try self.refreshLine(editState: editState)
+    }
+  }
+
+  private func moveHistory(editState: EditState,
+                           direction: LineReaderHistory.HistoryDirection) throws {
+    // If we're at the end of history (editing the current line), push it into a temporary
+    // buffer so it can be retrieved later
+    if self.history.currentIndex == self.history.historyItems.count {
+      tempBuf = editState.buffer
+    } else if self.preserveHistoryEdits {
+      self.history.replaceCurrent(editState.buffer)
+    }
+    if let historyItem = self.history.navigateHistory(direction: direction) {
+      try self.setBuffer(editState: editState, new: historyItem)
+    } else if case .next = direction {
+      try self.setBuffer(editState: editState, new: tempBuf ?? "")
+    } else {
+      self.ringBell()
+    }
+  }
+
+  private func refreshHints(editState: EditState) throws -> String {
+    guard let hintsCallback = self.hintsCallback,
+          let (hint, properties) = hintsCallback(editState.buffer) else {
+      return ""
+    }
+    let currentLineLength = editState.prompt.count + editState.buffer.count
+    if hint.count + currentLineLength > self.numColumns {
+      return ""
+    } else {
+      return properties.apply(to: hint) + AnsiCodes.origTermColor
+    }
+  }
+
+  private func withRawMode(body: () throws -> ()) throws {
+    var originalTermios: termios = termios()
+    defer {
+      _ = tcsetattr(self.inputFile, TCSADRAIN, &originalTermios)
+    }
+    if tcgetattr(self.inputFile, &originalTermios) == -1 {
+      throw LineReaderError.generalError("could not get term attributes")
+    }
+    var raw = originalTermios
+    raw.c_iflag &= ~tcflag_t(BRKINT | ICRNL | INPCK | ISTRIP | IXON)
+    raw.c_oflag &= ~tcflag_t(OPOST)
+    raw.c_cflag |= tcflag_t(CS8)
+    raw.c_lflag &= ~tcflag_t(ECHO | ICANON | IEXTEN | ISIG)
+    // VMIN = 16
+    raw.c_cc.16 = 1
+    guard tcsetattr(self.inputFile, TCSADRAIN, &raw) >= 0 else {
+      throw LineReaderError.generalError("Could not set raw mode")
+    }
+    try body()
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/LineReaderError.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/LineReaderError.swift
@@ -1,0 +1,43 @@
+//
+//  LineReaderError.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+public enum LineReaderError: Error {
+  case generalError(String)
+  case EOF
+  case CTRLC
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/LineReaderHistory.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/LineReaderHistory.swift
@@ -1,0 +1,119 @@
+//
+//  LineReaderHistory.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2021 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+class LineReaderHistory {
+  
+  public enum HistoryDirection: Int {
+    case previous = -1
+    case next = 1
+  }
+  
+  var maxLength: UInt = 0 {
+    didSet {
+      if history.count > maxLength && maxLength > 0 {
+        history.removeFirst(history.count - Int(maxLength))
+      }
+    }
+  }
+  private var index: Int = 0
+  
+  var currentIndex: Int {
+    return index
+  }
+  
+  private var hasTempItem: Bool = false
+  
+  private var history: [String] = [String]()
+  var historyItems: [String] {
+    return history
+  }
+  
+  public func add(_ item: String) {
+    // Don't add a duplicate if the last item is equal to this one
+    if let lastItem = history.last {
+      if lastItem == item {
+        index = history.endIndex
+        return
+      }
+    }
+    // Remove an item if we have reached maximum length
+    if maxLength > 0 && history.count >= maxLength {
+      _ = history.removeFirst()
+    }
+    history.append(item)
+    index = history.endIndex
+  }
+  
+  func replaceCurrent(_ item: String) {
+    history[index] = item
+  }
+  
+  internal func navigateHistory(direction: HistoryDirection) -> String? {
+    if history.count == 0 {
+      return nil
+    }
+    switch direction {
+    case .next:
+      index += HistoryDirection.next.rawValue
+    case .previous:
+      index += HistoryDirection.previous.rawValue
+    }
+    // Stop at the beginning and end of history
+    if index < 0 {
+      index = 0
+      return nil
+    } else if index >= history.count {
+      index = history.count
+      return nil
+    }
+    return history[index]
+  }
+  
+  internal func save(toFile path: String) throws {
+    let output = history.joined(separator: "\n")
+    try output.write(toFile: path, atomically: true, encoding: .utf8)
+  }
+  
+  internal func load(fromFile path: String) throws {
+    let input = try String(contentsOfFile: path, encoding: .utf8)
+    
+    input.split(separator: "\n").forEach {
+      add(String($0))
+    }
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/Terminal.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/Terminal.swift
@@ -1,0 +1,136 @@
+//
+//  Terminal.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 19/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+public struct Terminal {
+  
+  public static let current: String = ProcessInfo.processInfo.environment["TERM"] ?? ""
+  
+  public static var fullColorSupport: Bool {
+    // First make sure we are not running within Xcode
+    guard ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] == nil else {
+      return false
+    }
+    // Next, check if there is an environment variable COLORTERM set to "truecolor"
+    if let cterm = ProcessInfo.processInfo.environment["COLORTERM"], cterm == "truecolor" {
+      return true
+    }
+    // Finally, apply some heuristics based on the current terminal
+    return Terminal.fullColorSupport(terminal: Terminal.current)
+  }
+  
+  public static func fullColorSupport(terminal: String) -> Bool {
+    // A rather dumb way of detecting colour support
+    return terminal.contains("256")
+  }
+  
+  // Colour tables from https://jonasjacek.github.io/colors/
+  // Format: (r, g, b)
+  
+  private static let colors: [(UInt8, UInt8, UInt8)] = [
+    // Standard
+    (0, 0, 0), (128, 0, 0), (0, 128, 0), (128, 128, 0), (0, 0, 128), (128, 0, 128),
+    (0, 128, 128), (192, 192, 192),
+    // High intensity
+    (128, 128, 128), (255, 0, 0), (0, 255, 0), (255, 255, 0), (0, 0, 255), (255, 0, 255),
+    (0, 255, 255), (255, 255, 255),
+    // 256 color extended
+    (0, 0, 0), (0, 0, 95), (0, 0, 135), (0, 0, 175), (0, 0, 215), (0, 0, 255), (0, 95, 0),
+    (0, 95, 95), (0, 95, 135), (0, 95, 175), (0, 95, 215), (0, 95, 255), (0, 135, 0),
+    (0, 135, 95), (0, 135, 135), (0, 135, 175), (0, 135, 215), (0, 135, 255), (0, 175, 0),
+    (0, 175, 95), (0, 175, 135), (0, 175, 175), (0, 175, 215), (0, 175, 255), (0, 215, 0),
+    (0, 215, 95), (0, 215, 135), (0, 215, 175), (0, 215, 215), (0, 215, 255), (0, 255, 0),
+    (0, 255, 95), (0, 255, 135), (0, 255, 175), (0, 255, 215), (0, 255, 255), (95, 0, 0),
+    (95, 0, 95), (95, 0, 135), (95, 0, 175), (95, 0, 215), (95, 0, 255), (95, 95, 0),
+    (95, 95, 95), (95, 95, 135), (95, 95, 175), (95, 95, 215), (95, 95, 255), (95, 135, 0),
+    (95, 135, 95), (95, 135, 135), (95, 135, 175), (95, 135, 215), (95, 135, 255), (95, 175, 0),
+    (95, 175, 95), (95, 175, 135), (95, 175, 175), (95, 175, 215), (95, 175, 255), (95, 215, 0),
+    (95, 215, 95), (95, 215, 135), (95, 215, 175), (95, 215, 215), (95, 215, 255), (95, 255, 0),
+    (95, 255, 95), (95, 255, 135), (95, 255, 175), (95, 255, 215), (95, 255, 255), (135, 0, 0),
+    (135, 0, 95), (135, 0, 135), (135, 0, 175), (135, 0, 215), (135, 0, 255), (135, 95, 0),
+    (135, 95, 95), (135, 95, 135), (135, 95, 175), (135, 95, 215), (135, 95, 255), (135, 135, 0),
+    (135, 135, 95), (135, 135, 135), (135, 135, 175), (135, 135, 215), (135, 135, 255),
+    (135, 175, 0), (135, 175, 95), (135, 175, 135), (135, 175, 175), (135, 175, 215),
+    (135, 175, 255), (135, 215, 0), (135, 215, 95), (135, 215, 135), (135, 215, 175),
+    (135, 215, 215), (135, 215, 255), (135, 255, 0), (135, 255, 95), (135, 255, 135),
+    (135, 255, 175), (135, 255, 215), (135, 255, 255), (175, 0, 0), (175, 0, 95), (175, 0, 135),
+    (175, 0, 175), (175, 0, 215), (175, 0, 255), (175, 95, 0), (175, 95, 95), (175, 95, 135),
+    (175, 95, 175), (175, 95, 215), (175, 95, 255), (175, 135, 0), (175, 135, 95),
+    (175, 135, 135), (175, 135, 175), (175, 135, 215), (175, 135, 255), (175, 175, 0),
+    (175, 175, 95), (175, 175, 135), (175, 175, 175), (175, 175, 215), (175, 175, 255),
+    (175, 215, 0), (175, 215, 95), (175, 215, 135), (175, 215, 175), (175, 215, 215),
+    (175, 215, 255), (175, 255, 0), (175, 255, 95), (175, 255, 135), (175, 255, 175),
+    (175, 255, 215), (175, 255, 255), (215, 0, 0), (215, 0, 95), (215, 0, 135), (215, 0, 175),
+    (215, 0, 215), (215, 0, 255), (215, 95, 0), (215, 95, 95), (215, 95, 135), (215, 95, 175),
+    (215, 95, 215), (215, 95, 255), (215, 135, 0), (215, 135, 95), (215, 135, 135),
+    (215, 135, 175), (215, 135, 215), (215, 135, 255), (215, 175, 0), (215, 175, 95),
+    (215, 175, 135), (215, 175, 175), (215, 175, 215), (215, 175, 255), (215, 215, 0),
+    (215, 215, 95), (215, 215, 135), (215, 215, 175), (215, 215, 215), (215, 215, 255),
+    (215, 255, 0), (215, 255, 95), (215, 255, 135), (215, 255, 175), (215, 255, 215),
+    (215, 255, 255), (255, 0, 0), (255, 0, 95), (255, 0, 135), (255, 0, 175), (255, 0, 215),
+    (255, 0, 255), (255, 95, 0), (255, 95, 95), (255, 95, 135), (255, 95, 175), (255, 95, 215),
+    (255, 95, 255), (255, 135, 0), (255, 135, 95), (255, 135, 135), (255, 135, 175),
+    (255, 135, 215), (255, 135, 255), (255, 175, 0), (255, 175, 95), (255, 175, 135),
+    (255, 175, 175), (255, 175, 215), (255, 175, 255), (255, 215, 0), (255, 215, 95),
+    (255, 215, 135), (255, 215, 175), (255, 215, 215), (255, 215, 255), (255, 255, 0),
+    (255, 255, 95), (255, 255, 135), (255, 255, 175), (255, 255, 215), (255, 255, 255),
+    (8, 8, 8), (18, 18, 18), (28, 28, 28), (38, 38, 38), (48, 48, 48), (58, 58, 58),
+    (68, 68, 68), (78, 78, 78), (88, 88, 88), (98, 98, 98), (108, 108, 108), (118, 118, 118),
+    (128, 128, 128), (138, 138, 138), (148, 148, 148), (158, 158, 158), (168, 168, 168),
+    (178, 178, 178), (188, 188, 188), (198, 198, 198), (208, 208, 208), (218, 218, 218),
+    (228, 228, 228), (238, 238, 238)
+  ]
+  
+  internal static func closestColor(to targetColor: (UInt8, UInt8, UInt8),
+                                    fullColorSupport all256: Bool = false) -> UInt8 {
+    let colorTable: [(UInt8, UInt8, UInt8)] = all256 ? colors : Array(colors[0..<8])
+    let distances = colorTable.map {
+      sqrt(pow(Double(Int($0.0) - Int(targetColor.0)), 2) +
+           pow(Double(Int($0.1) - Int(targetColor.1)), 2) +
+           pow(Double(Int($0.2) - Int(targetColor.2)), 2))
+    }
+    var closest = Double.greatestFiniteMagnitude
+    var closestIdx = 0
+    for i in 0..<distances.count {
+      if distances[i] < closest  {
+        closest = distances[i]
+        closestIdx = i
+      }
+    }
+    return UInt8(closestIdx)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/TextColor.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/TextColor.swift
@@ -1,0 +1,172 @@
+//
+//  TextColor.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 07/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// Enumeration of all supported text colors.
+/// 
+public enum TextColor: Hashable {
+  case black
+  case maroon
+  case green
+  case olive
+  case navy
+  case purple
+  case teal
+  case silver
+  case `default`
+  case grey
+  case red
+  case lime
+  case yellow
+  case blue
+  case fuchsia
+  case aqua
+  case white
+  case extended(UInt8)
+  
+  public init?(colorCode: UInt8, fullColorSupport all256: Bool = false) {
+    if all256 {
+      self = .extended(colorCode)
+    } else {
+      switch colorCode {
+        case 30:
+          self = .black
+        case 31:
+          self = .maroon
+        case 32:
+          self = .green
+        case 33:
+          self = .olive
+        case 34:
+          self = .navy
+        case 35:
+          self = .purple
+        case 36:
+          self = .teal
+        case 37:
+          self = .silver
+        case 39:
+          self = .default
+        case 90:
+          self = .grey
+        case 91:
+          self = .red
+        case 92:
+          self = .lime
+        case 93:
+          self = .yellow
+        case 94:
+          self = .blue
+        case 95:
+          self = .fuchsia
+        case 96:
+          self = .aqua
+        case 97:
+          self = .white
+        default:
+          return nil
+      }
+    }
+  }
+  
+  public init(color: (UInt8, UInt8, UInt8), fullColorSupport all256: Bool = false) {
+    let code = Terminal.closestColor(to: color, fullColorSupport: all256)
+    if all256 {
+      self = .extended(code)
+    } else {
+      let color: TextColor?
+      if code < 8 {
+        color = TextColor(colorCode: code + 30)
+      } else if code < 16 {
+        color = TextColor(colorCode: code + 90)
+      } else {
+        color = nil
+      }
+      self = color ?? .default
+    }
+  }
+  
+  public var code: UInt8 {
+    switch self {
+      case .black:
+        return 30
+      case .maroon:
+        return 31
+      case .green:
+        return 32
+      case .olive:
+        return 33
+      case .navy:
+        return 34
+      case .purple:
+        return 35
+      case .teal:
+        return 36
+      case .silver:
+        return 37
+      case .default:
+        return 39
+      case .grey:
+        return 90
+      case .red:
+        return 91
+      case .lime:
+        return 92
+      case .yellow:
+        return 93
+      case .blue:
+        return 94
+      case .fuchsia:
+        return 95
+      case .aqua:
+        return 96
+      case .white:
+        return 97
+      case .extended(let c):
+        return c
+    }
+  }
+  
+  public var isExtended: Bool {
+    guard case .extended(_) = self else {
+      return false
+    }
+    return true
+  }
+  
+  public var properties: TextProperties {
+    return TextProperties(textColor: self)
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/TextProperties.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/TextProperties.swift
@@ -1,0 +1,185 @@
+//
+//  TextProperties.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 18/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// A `TextProperties` struct bundles a text color, a background color and a text style
+/// in one object. Text properties can be merged with the `with(:)` functions and applied to
+/// a string with the `apply(to:)` function.
+///
+public struct TextProperties: Hashable {
+  let textColor: TextColor?
+  let backgroundColor: BackgroundColor?
+  let textStyles: Set<TextStyle>
+  
+  public static let none = TextProperties()
+  
+  public init(textColor: TextColor? = nil,
+              backgroundColor: BackgroundColor? = nil,
+              textStyles: Set<TextStyle> = []) {
+    self.textColor = textColor
+    self.backgroundColor = backgroundColor
+    self.textStyles = textStyles
+  }
+  
+  public init(_ tcolor: TextColor? = nil,
+              _ bgcolor: BackgroundColor? = nil,
+              _ tstyles: TextStyle...) {
+    self.textColor = tcolor
+    self.textStyles = Set(tstyles)
+    self.backgroundColor = bgcolor
+  }
+  
+  public var isEmpty: Bool {
+    return self.textColor == nil && self.backgroundColor == nil && self.textStyles.isEmpty
+  }
+  
+  public func with(_ properties: TextProperties) -> TextProperties {
+    var styles = self.textStyles
+    for style in properties.textStyles {
+      styles.insert(style)
+    }
+    return TextProperties(textColor: properties.textColor ?? self.textColor,
+                          backgroundColor: properties.backgroundColor ?? self.backgroundColor,
+                          textStyles: styles)
+  }
+  
+  public func with(_ tcolor: TextColor) -> TextProperties {
+    return TextProperties(textColor: tcolor,
+                          backgroundColor: self.backgroundColor,
+                          textStyles: self.textStyles)
+  }
+  
+  public func with(_ bgcolor: BackgroundColor) -> TextProperties {
+    return TextProperties(textColor: self.textColor,
+                          backgroundColor: bgcolor,
+                          textStyles: self.textStyles)
+  }
+  
+  public func with(_ tstyle: TextStyle) -> TextProperties {
+    var styles = self.textStyles
+    styles.insert(tstyle)
+    return TextProperties(textColor: self.textColor,
+                          backgroundColor: self.backgroundColor,
+                          textStyles: styles)
+  }
+  
+  public func apply(to text: String) -> String {
+    if self.isEmpty {
+      return text
+    }
+    var codes: [UInt8] = []
+    if let color = self.textColor {
+      if color.isExtended {
+        codes.append(38)
+        codes.append(5)
+      }
+      codes.append(color.code)
+    }
+    if let backgroundColor = self.backgroundColor {
+      if backgroundColor.isExtended {
+        codes.append(48)
+        codes.append(5)
+      }
+      codes.append(backgroundColor.code)
+    }
+    codes += self.textStyles.map { $0.code }
+    return codes.isEmpty ?
+      text :
+      "\(AnsiCodes.CSI)\(codes.map{String($0)}.joined(separator: ";"))m\(text)\(AnsiCodes.CSI)0m"
+  }
+  
+  public static func extract(from str: String) -> (TextProperties, String) {
+    let (codes, res) = TextProperties.extractCodes(from: str)
+    return (TextProperties.interpret(codes: codes), res)
+  }
+  
+  private static func extractCodes(from string: String) -> ([UInt8], String) {
+    var index = string.index(string.startIndex, offsetBy: AnsiCodes.CSI.count)
+    var codesString = ""
+    while string[index] != "m" {
+      codesString.append(string[index])
+      index = string.index(after: index)
+    }
+    let codes = codesString.split(separator: ";",
+                                  omittingEmptySubsequences: false).compactMap { UInt8($0) }
+    let startIndex = string.index(after: index)
+    let endIndex = string.index(string.endIndex, offsetBy: -"\(AnsiCodes.CSI)0m".count)
+    let text = String(string[startIndex..<endIndex])
+    return (codes, text)
+  }
+  
+  private static func interpret(codes: [UInt8]) -> TextProperties {
+    var color: TextColor? = nil
+    var backgroundColor: BackgroundColor? = nil
+    var styles: Set<TextStyle> = []
+    var i = 0
+    while i < codes.count {
+      if (i + 2) < codes.count {
+        if codes[i] == 38 && codes[i + 1] == 5 {
+          color = TextColor(colorCode: codes[i + 2], fullColorSupport: true)
+          i += 2
+          continue
+        } else if codes[i] == 48 && codes[i + 1] == 5 {
+          backgroundColor = BackgroundColor(colorCode: codes[i + 2], fullColorSupport: true)
+          i += 2
+          continue
+        }
+      }
+      if let c = TextColor(colorCode: codes[i]) {
+        color = c
+      } else if let bg = BackgroundColor(colorCode: codes[i]) {
+        backgroundColor = bg
+      } else if let style = TextStyle(rawValue: codes[i]) {
+        styles.insert(style)
+      }
+      i += 1
+    }
+    return TextProperties(textColor: color,
+                          backgroundColor: backgroundColor,
+                          textStyles: styles)
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.textColor)
+    hasher.combine(self.textStyles)
+    hasher.combine(self.backgroundColor)
+  }
+  
+  public static func == (lhs: TextProperties, rhs: TextProperties) -> Bool {
+    return lhs.textColor == rhs.textColor &&
+           lhs.backgroundColor == rhs.backgroundColor &&
+           lhs.textStyles == rhs.textStyles
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKit/TextStyle.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKit/TextStyle.swift
@@ -1,0 +1,55 @@
+//
+//  TextStyle.swift
+//  CommandLineKit
+//
+//  Created by Matthias Zenger on 18/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+
+///
+/// Enumeration of all supported text styles.
+/// 
+public enum TextStyle: UInt8, Hashable {
+  case `default` = 0
+  case bold = 1
+  case dim = 2
+  case italic = 3
+  case underline = 4
+  case blink = 5
+  case swap = 7
+  
+  public var code: UInt8 {
+    return self.rawValue
+  }
+  
+  public var properties: TextProperties {
+    return TextProperties(textStyles: [self])
+  }
+}

--- a/External/swift-commandlinekit/Sources/CommandLineKitDemo/Info.plist
+++ b/External/swift-commandlinekit/Sources/CommandLineKitDemo/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2018-2023 Google LLC</string>
+</dict>
+</plist>

--- a/External/swift-commandlinekit/Sources/CommandLineKitDemo/LinuxMain.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKitDemo/LinuxMain.swift
@@ -1,0 +1,40 @@
+//
+//  LinuxMain.swift
+//  CommandLineKitDemo
+//
+//  Created by Matthias Zenger on 02/06/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+#if os(Linux)
+@main struct CommandLineKitDemo {
+  static func main() {
+    demo()
+  }
+}
+#endif

--- a/External/swift-commandlinekit/Sources/CommandLineKitDemo/main.swift
+++ b/External/swift-commandlinekit/Sources/CommandLineKitDemo/main.swift
@@ -1,0 +1,90 @@
+//
+//  main.swift
+//  CommandLineKitDemo
+//
+//  Created by Matthias Zenger on 08/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import Foundation
+import CommandLineKit
+
+func demo() {
+  print("Detected terminal: \(Terminal.current)")
+  print(Terminal.fullColorSupport ? "Full color support" : "No color support")
+  print(LineReader.supportedByTerminal ? "LineReader support" : "No LineReader support")
+
+  if let ln = LineReader() {
+    ln.setCompletionCallback { currentBuffer in
+      let completions = [
+        "Hello, world!",
+        "Hello, Linenoise!",
+        "Swift is Awesome!"
+      ]
+      return completions.filter { $0.hasPrefix(currentBuffer) }
+    }
+    ln.setHintsCallback { currentBuffer in
+      let hints = [
+        "Carpe Diem",
+        "Lorem Ipsum",
+        "Swift is Awesome!"
+      ]
+      let filtered = hints.filter { $0.hasPrefix(currentBuffer) }
+      if let hint = filtered.first {
+        let hintText = String(hint.dropFirst(currentBuffer.count))
+        return (hintText, TextColor.grey.properties)
+      } else {
+        return nil
+      }
+    }
+    print("Type 'exit' to quit")
+    var done = false
+    while !done {
+      do {
+        let output = try ln.readLine(prompt: "> ",
+                                     maxCount: 200,
+                                     strippingNewline: true,
+                                     promptProperties: TextProperties(.green, nil, .bold),
+                                     readProperties: TextProperties(.blue, nil),
+                                     parenProperties: TextProperties(.red, nil, .bold))
+        print("Entered: \(output)")
+        ln.addHistory(output)
+        if output == "exit" {
+          break
+        }
+      } catch LineReaderError.CTRLC {
+        print("\nCaptured CTRL+C. Quitting.")
+        done = true
+      } catch {
+        print(error)
+      }
+    }
+  }
+}
+
+demo()

--- a/External/swift-commandlinekit/Tests/CommandLineKitTests/AnsiCodesTests.swift
+++ b/External/swift-commandlinekit/Tests/CommandLineKitTests/AnsiCodesTests.swift
@@ -1,0 +1,69 @@
+//
+//  AnsiCodesTests.swift
+//  CommandLineKitTests
+//
+//  Created by Matthias Zenger on 08/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import XCTest
+@testable import CommandLineKit
+
+class AnsiCodesTests: XCTestCase {
+
+  func testGenerateEscapeCode() {
+    XCTAssertEqual(AnsiCodes.escapeCode("foo"), "\u{001B}[foo")
+  }
+  
+  func testEraseRight() {
+    XCTAssertEqual(AnsiCodes.eraseRight, "\u{001B}[0K")
+  }
+  
+  func testCursorForward() {
+    XCTAssertEqual(AnsiCodes.cursorForward(10), "\u{001B}[10C")
+  }
+  
+  func testClearScreen() {
+    XCTAssertEqual(AnsiCodes.clearScreen, "\u{001B}[2J")
+  }
+  
+  func testHomeCursor() {
+    XCTAssertEqual(AnsiCodes.homeCursor, "\u{001B}[H")
+  }
+  
+  static let allTests = [
+    ("testGenerateEscapeCode", testGenerateEscapeCode),
+    ("testEraseRight", testEraseRight),
+    ("testCursorForward", testCursorForward),
+    ("testClearScreen", testClearScreen),
+    ("testHomeCursor", testHomeCursor),
+  ]
+}

--- a/External/swift-commandlinekit/Tests/CommandLineKitTests/EditStateTests.swift
+++ b/External/swift-commandlinekit/Tests/CommandLineKitTests/EditStateTests.swift
@@ -1,0 +1,193 @@
+//
+//  EditStateTests.swift
+//  CommandLineKitTests
+//
+//  Created by Matthias Zenger on 08/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import XCTest
+@testable import CommandLineKit
+
+class EditStateTests: XCTestCase {
+
+  func testInitEmptyBuffer() {
+    let s = EditState(prompt: "$ ")
+    XCTAssertEqual(s.buffer, "")
+    XCTAssertEqual(s.location, s.buffer.startIndex)
+    XCTAssertEqual(s.prompt, "$ ")
+  }
+  
+  func testInsertCharacter() {
+    let s = EditState(prompt: "")
+    XCTAssert(s.insertCharacter("A"["A".startIndex]))
+    XCTAssertEqual(s.buffer, "A")
+    XCTAssertEqual(s.location, s.buffer.endIndex)
+    XCTAssertEqual(s.cursorPosition, 1)
+  }
+  
+  func testBackspace() {
+    let s = EditState(prompt: "")
+    XCTAssert(s.insertCharacter("A"["A".startIndex]))
+    XCTAssertTrue(s.backspace())
+    XCTAssertEqual(s.buffer, "")
+    XCTAssertEqual(s.location, s.buffer.startIndex)
+    // No more characters left, so backspace should return false
+    XCTAssertFalse(s.backspace())
+  }
+  
+  func testMoveLeft() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.endIndex
+    XCTAssertTrue(s.moveLeft())
+    XCTAssertEqual(s.cursorPosition, 4)
+    s.location = s.buffer.startIndex
+    XCTAssertFalse(s.moveLeft())
+  }
+
+  func testMoveRight() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.startIndex
+    XCTAssertTrue(s.moveRight())
+    XCTAssertEqual(s.cursorPosition, 1)
+    s.location = s.buffer.endIndex
+    XCTAssertFalse(s.moveRight())
+  }
+  
+  func testMoveHome() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.endIndex
+    XCTAssertTrue(s.moveHome())
+    XCTAssertEqual(s.cursorPosition, 0)
+    XCTAssertFalse(s.moveHome())
+  }
+  
+  func testMoveEnd() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.startIndex
+    XCTAssertTrue(s.moveEnd())
+    XCTAssertEqual(s.cursorPosition, 5)
+    XCTAssertFalse(s.moveEnd())
+  }
+  
+  func testRemovePreviousWord() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello world"
+    s.location = s.buffer.endIndex
+    XCTAssertTrue(s.deletePreviousWord())
+    XCTAssertEqual(s.buffer, "Hello ")
+    XCTAssertEqual(s.location, "Hello ".endIndex)
+    s.buffer = ""
+    s.location = s.buffer.endIndex
+    XCTAssertFalse(s.deletePreviousWord())
+    // Test with cursor location in the middle of the text
+    s.buffer = "This is a test"
+    s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 8)
+    XCTAssertTrue(s.deletePreviousWord())
+    XCTAssertEqual(s.buffer, "This a test")
+  }
+  
+  func testDeleteToEndOfLine() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello world"
+    s.location = s.buffer.endIndex
+    XCTAssertFalse(s.deleteToEndOfLine())
+    s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 5)
+    XCTAssertTrue(s.deleteToEndOfLine())
+    XCTAssertEqual(s.buffer, "Hello")
+  }
+  
+  func testDeleteCharacter() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello world"
+    s.location = s.buffer.endIndex
+    XCTAssertFalse(s.deleteCharacter())
+    s.location = s.buffer.startIndex
+    XCTAssertTrue(s.deleteCharacter())
+    XCTAssertEqual(s.buffer, "ello world")
+    s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 5)
+    XCTAssertTrue(s.deleteCharacter())
+    XCTAssertEqual(s.buffer, "ello orld")
+  }
+  
+  func testEraseCharacterRight() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.endIndex
+    XCTAssertFalse(s.eraseCharacterRight())
+    s.location = s.buffer.startIndex
+    XCTAssertTrue(s.eraseCharacterRight())
+    XCTAssertEqual(s.buffer, "ello")
+    // Test empty buffer
+    s.buffer = ""
+    s.location = s.buffer.startIndex
+    XCTAssertFalse(s.eraseCharacterRight())
+  }
+  
+  func testSwapCharacters() {
+    let s = EditState(prompt: "")
+    s.buffer = "Hello"
+    s.location = s.buffer.endIndex
+    // Cursor at the end of the text
+    XCTAssertTrue(s.swapCharacterWithPrevious())
+    XCTAssertEqual(s.buffer, "Helol")
+    XCTAssertEqual(s.location, s.buffer.endIndex)
+    // Cursor in the middle of the text
+    s.location = s.buffer.index(before: s.buffer.endIndex)
+    XCTAssertTrue(s.swapCharacterWithPrevious())
+    XCTAssertEqual(s.buffer, "Hello")
+    XCTAssertEqual(s.location, s.buffer.endIndex)
+    // Cursor at the start of the text
+    s.location = s.buffer.startIndex
+    XCTAssertTrue(s.swapCharacterWithPrevious())
+    XCTAssertEqual(s.buffer, "eHllo")
+    XCTAssertEqual(s.location, s.buffer.index(s.buffer.startIndex, offsetBy: 2))
+  }
+  
+  static let allTests = [
+    ("testInitEmptyBuffer", testInitEmptyBuffer),
+    ("testInsertCharacter", testInsertCharacter),
+    ("testBackspace", testBackspace),
+    ("testMoveLeft", testMoveLeft),
+    ("testMoveRight", testMoveRight),
+    ("testMoveHome", testMoveHome),
+    ("testMoveEnd", testMoveEnd),
+    ("testRemovePreviousWord", testRemovePreviousWord),
+    ("testDeleteToEndOfLine", testDeleteToEndOfLine),
+    ("testDeleteCharacter", testDeleteCharacter),
+    ("testEraseCharacterRight", testEraseCharacterRight),
+    ("testSwapCharacters", testSwapCharacters),
+  ]
+}

--- a/External/swift-commandlinekit/Tests/CommandLineKitTests/FlagTests.swift
+++ b/External/swift-commandlinekit/Tests/CommandLineKitTests/FlagTests.swift
@@ -1,0 +1,184 @@
+//
+//  FlagTests.swift
+//  CommandLineKitTests
+//
+//  Created by Matthias Zenger on 25/03/2017.
+//  Copyright © 2018-2023 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import XCTest
+@testable import CommandLineKit
+
+class FlagTests: XCTestCase {
+  
+  func testLongFlagNames2() throws {
+    let flags = Flags(arguments: ["--one", "--four", "912", "--three", "--five", "-3.141",
+                                  "--six", "six", "seven"])
+    let one = flags.option(nil, "one", description: "the one option")
+    let two = flags.option(nil, "two", description: "the two option")
+    let three = flags.option(nil, "three", description: "the three option")
+    let four = flags.argument(nil, "four", description: "the four option for ints", value: 0)
+    let five = flags.double(nil, "five", description: "the five option for doubles")
+    let six = flags.string(nil, "six", description: "the six option for strings")
+    let seven = flags.string(nil, "seven", description: "the seven option for strings")
+    try flags.parse()
+    XCTAssert(one.wasSet)
+    XCTAssert(!two.wasSet)
+    XCTAssert(three.wasSet)
+    XCTAssert(four.value != nil && four.value! == 912)
+    XCTAssert(five.value != nil && five.value! == -3.141)
+    XCTAssert(six.value != nil && six.value! == "six")
+    XCTAssertNil(seven.value)
+    XCTAssert(flags.parameters.count == 1 && flags.parameters[0] == "seven")
+  }
+  
+  func testLongFlagNames() throws {
+    let flags = Flags(arguments: ["--one", "--four", "912", "--three", "--five", "-3.141",
+                                  "--six", "six", "seven"])
+    let one = flags.option(nil, "one", description: "the one option")
+    let two = flags.option(nil, "two", description: "the two option")
+    let three = flags.option(nil, "three", description: "the three option")
+    let four = flags.int(nil, "four", description: "the four option for ints")
+    let five = flags.double(nil, "five", description: "the five option for doubles")
+    let six = flags.string(nil, "six", description: "the six option for strings")
+    let seven = flags.string(nil, "seven", description: "the seven option for strings")
+    try flags.parse()
+    XCTAssert(one.wasSet)
+    XCTAssert(!two.wasSet)
+    XCTAssert(three.wasSet)
+    XCTAssert(four.value != nil && four.value! == 912)
+    XCTAssert(five.value != nil && five.value! == -3.141)
+    XCTAssert(six.value != nil && six.value! == "six")
+    XCTAssertNil(seven.value)
+    XCTAssert(flags.parameters.count == 1 && flags.parameters[0] == "seven")
+  }
+  
+  func testShortFlagNames() throws {
+    let flags = Flags(arguments: ["-a", "-d", "912", "-c", "-e", "-3.141",
+                                  "-f", "six", "seven"])
+    let one = flags.option("a", description: "the one option")
+    let two = flags.option("b", description: "the two option")
+    let three = flags.option("c", description: "the three option")
+    let four = flags.int("d", description: "the four option for ints")
+    let five = flags.double("e", description: "the five option for doubles")
+    let six = flags.string("f", description: "the six option for strings")
+    let seven = flags.string("g", description: "the seven option for strings")
+    try flags.parse()
+    XCTAssert(one.wasSet)
+    XCTAssert(!two.wasSet)
+    XCTAssert(three.wasSet)
+    XCTAssert(four.value != nil && four.value! == 912)
+    XCTAssert(five.value != nil && five.value! == -3.141)
+    XCTAssert(six.value != nil && six.value! == "six")
+    XCTAssertNil(seven.value)
+    XCTAssert(flags.parameters.count == 1 && flags.parameters[0] == "seven")
+  }
+  
+  func testCommandFlags() throws {
+    struct TestCommand: Command {
+      static var executed = false
+      static var flagsOk = false
+      static var name: String {
+        return "TestTool"
+      }
+      static var arguments: [String] {
+        return ["--size", "23", "-h", "--repeated", "hello", "world", "!"]
+      }
+      @CommandOption(short: "h", description: "help") var help: Bool
+      @CommandArgument(description: "count") var count: Int = 7
+      @CommandArgument(description: "size") var size: Int?
+      @CommandArguments(description: "repeated", maxCount: 3) var repeated: [String]
+      @CommandParameters var params: [String]
+      @CommandFlags var flags: Flags
+      mutating func run() {
+        TestCommand.executed = true
+        TestCommand.flagsOk = self.size == 23 && self.help && self.repeated.count == 3 &&
+                              self.flags.toolName == "TestTool"
+      }
+    }
+    try TestCommand.main()
+    XCTAssert(TestCommand.executed)
+    XCTAssert(TestCommand.flagsOk)
+  }
+  
+  func testCommandFlagsFailure() throws {
+    struct TestCommand: Command {
+      static var executed = false
+      static var arguments: [String] {
+        return ["--foo", "23"]
+      }
+      @CommandOption(short: "h", description: "help") var help: Bool
+      @CommandArgument(description: "count") var count: Int = 7
+      @CommandArgument(description: "size") var size: Int?
+      @CommandArguments(description: "repeated", maxCount: 3) var repeated: [String]
+      @CommandParameters var params: [String]
+      @CommandFlags var flags: Flags
+      mutating func fail(with: String) {
+        TestCommand.executed = false
+      }
+      mutating func run() {
+        TestCommand.executed = true
+      }
+    }
+    try TestCommand.main()
+    XCTAssert(!TestCommand.executed)
+  }
+  
+  func testMoreCommandFlags() throws {
+    struct TestCommand: Command {
+      static var executed = false
+      static var arguments: [String] {
+        return []
+      }
+      @CommandArguments(short: "f", description: "Adds file path in which programs are searched for.")
+      var filePath: [String]
+      @CommandArguments(short: "l", description: "Adds file path in which libraries are searched for.")
+      var libPaths: [String]
+      @CommandArgument(short: "x", description: "Initial capacity of the heap")
+      var heapSize: Int = 1234
+      @CommandOption(short: "h", description: "Show description of usage and options of this tools.")
+      var help: Bool
+      @CommandFlags
+      var flags: Flags
+      mutating func run() {
+        TestCommand.executed = true
+      }
+    }
+    try TestCommand.main()
+    XCTAssert(TestCommand.executed)
+  }
+  
+  static let allTests = [
+    ("testLongFlagNames2", testLongFlagNames2),
+    ("testLongFlagNames", testLongFlagNames),
+    ("testShortFlagNames", testShortFlagNames),
+    ("testCommandFlags", testCommandFlags),
+    ("testCommandFlagsFailure", testCommandFlagsFailure),
+    ("testMoreCommandFlags", testMoreCommandFlags),
+  ]
+}

--- a/External/swift-commandlinekit/Tests/CommandLineKitTests/Info.plist
+++ b/External/swift-commandlinekit/Tests/CommandLineKitTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.3.4</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/External/swift-commandlinekit/Tests/CommandLineKitTests/LineReaderHistoryTests.swift
+++ b/External/swift-commandlinekit/Tests/CommandLineKitTests/LineReaderHistoryTests.swift
@@ -1,0 +1,191 @@
+//
+//  LineReaderHistoryTests.swift
+//  CommandLineKitTests
+//
+//  Created by Matthias Zenger on 08/04/2018.
+//  Copyright © 2018-2019 Google LLC
+//  Copyright © 2017 Andy Best <andybest.net at gmail dot com>
+//  Copyright © 2010-2014 Salvatore Sanfilippo <antirez at gmail dot com>
+//  Copyright © 2010-2013 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+
+import XCTest
+@testable import CommandLineKit
+
+class LineReaderHistoryTests: XCTestCase {
+  
+  func testHistoryAddItem() {
+    let h = LineReaderHistory()
+    h.add("Test")
+    XCTAssertEqual(h.historyItems, ["Test"])
+  }
+  
+  func testHistoryDoesNotAddDuplicatedLines() {
+    let h = LineReaderHistory()
+    h.add("Test")
+    h.add("Test")
+    XCTAssertEqual(h.historyItems.count, 1)
+    // Test adding a new item in-between doesn't de-dupe the newest line
+    h.add("Test 2")
+    h.add("Test")
+    XCTAssertEqual(h.historyItems.count, 3)
+  }
+  
+  func testHistoryHonorsMaxLength() {
+    let h = LineReaderHistory()
+    h.maxLength = 2
+    h.add("Test 1")
+    h.add("Test 2")
+    h.add("Test 3")
+    XCTAssertEqual(h.historyItems.count, 2)
+    XCTAssertEqual(h.historyItems, ["Test 2", "Test 3"])
+  }
+  
+  func testHistoryRemovesEntriesWhenMaxLengthIsSet() {
+    let h = LineReaderHistory()
+    h.add("Test 1")
+    h.add("Test 2")
+    h.add("Test 3")
+    XCTAssertEqual(h.historyItems.count, 3)
+    h.maxLength = 2
+    XCTAssertEqual(h.historyItems.count, 2)
+    XCTAssertEqual(h.historyItems, ["Test 2", "Test 3"])
+  }
+  
+  func testHistoryNavigationReturnsNilWhenHistoryEmpty() {
+    let h = LineReaderHistory()
+    XCTAssertNil(h.navigateHistory(direction: .next))
+    XCTAssertNil(h.navigateHistory(direction: .previous))
+  }
+  
+  func testHistoryNavigationReturnsSingleItemWhenHistoryHasOneItem() {
+    let h = LineReaderHistory()
+    h.add("Test")
+    XCTAssertNil(h.navigateHistory(direction: .next))
+    guard let previousItem = h.navigateHistory(direction: .previous) else {
+      XCTFail("Expected previous item to not be nil")
+      return
+    }
+    XCTAssertEqual(previousItem, "Test")
+  }
+  
+  func testHistoryStopsAtBeginning() {
+    let h = LineReaderHistory()
+    h.add("1")
+    h.add("2")
+    h.add("3")
+    XCTAssertEqual(h.navigateHistory(direction: .previous), "3")
+    XCTAssertEqual(h.navigateHistory(direction: .previous), "2")
+    XCTAssertEqual(h.navigateHistory(direction: .previous), "1")
+    XCTAssertNil(h.navigateHistory(direction: .previous))
+  }
+  
+  func testHistoryNavigationStopsAtEnd() {
+    let h = LineReaderHistory()
+    h.add("1")
+    h.add("2")
+    h.add("3")
+    XCTAssertNil(h.navigateHistory(direction: .next))
+  }
+  
+  func testHistorySavesToFile() {
+    let h = LineReaderHistory()
+    h.add("Test 1")
+    h.add("Test 2")
+    h.add("Test 3")
+    let tempFile = "/tmp/linereaderhistory_save_test.txt"
+    do {
+      try h.save(toFile: tempFile)
+    } catch {
+      XCTFail("Saving file should not throw exception")
+    }
+    let fileContents: String
+    do {
+      fileContents = try String(contentsOfFile: tempFile, encoding: .utf8)
+    } catch {
+      XCTFail("Loading file should not throw exception")
+      return
+    }
+    // Reading the file should yield the same lines as input
+    let items = fileContents.split(separator: "\n")
+    XCTAssertEqual(items, ["Test 1", "Test 2", "Test 3"])
+  }
+  
+  func testHistoryLoadsFromFile() {
+    let h = LineReaderHistory()
+    let tempFile = "/tmp/linereaderhistory_load_test.txt"
+    do {
+      try "Test 1\nTest 2\nTest 3".write(toFile: tempFile, atomically: true, encoding: .utf8)
+    } catch {
+      XCTFail("Writing file should not throw exception")
+    }
+    do {
+      try h.load(fromFile: tempFile)
+    } catch {
+      XCTFail("Loading file should not throw exception")
+      return
+    }
+    XCTAssertEqual(h.historyItems.count, 3)
+    XCTAssertEqual(h.historyItems, ["Test 1", "Test 2", "Test 3"])
+  }
+  
+  func testHistoryLoadingRespectsMaxLength() {
+    let h = LineReaderHistory()
+    h.maxLength = 2
+    let tempFile = "/tmp/linereaderhistory_load_test.txt"
+    do {
+      try "Test 1\nTest 2\nTest 3".write(toFile: tempFile, atomically: true, encoding: .utf8)
+    } catch {
+      XCTFail("Writing file should not throw exception")
+    }
+    do {
+      try h.load(fromFile: tempFile)
+    } catch {
+      XCTFail("Loading file should not throw exception")
+      return
+    }
+    XCTAssertEqual(h.historyItems.count, 2)
+    XCTAssertEqual(h.historyItems, ["Test 2", "Test 3"])
+  }
+  
+  static let allTests = [
+    ("testHistoryAddItem", testHistoryAddItem),
+    ("testHistoryDoesNotAddDuplicatedLines", testHistoryDoesNotAddDuplicatedLines),
+    ("testHistoryHonorsMaxLength", testHistoryHonorsMaxLength),
+    ("testHistoryRemovesEntriesWhenMaxLengthIsSet", testHistoryRemovesEntriesWhenMaxLengthIsSet),
+    ("testHistoryNavigationReturnsNilWhenHistoryEmpty",
+     testHistoryNavigationReturnsNilWhenHistoryEmpty),
+    ("testHistoryNavigationReturnsSingleItemWhenHistoryHasOneItem",
+     testHistoryNavigationReturnsSingleItemWhenHistoryHasOneItem),
+    ("testHistoryStopsAtBeginning", testHistoryStopsAtBeginning),
+    ("testHistoryNavigationStopsAtEnd", testHistoryNavigationStopsAtEnd),
+    ("testHistorySavesToFile", testHistorySavesToFile),
+    ("testHistoryLoadsFromFile", testHistoryLoadsFromFile),
+    ("testHistoryLoadingRespectsMaxLength", testHistoryLoadingRespectsMaxLength),
+  ]
+}

--- a/External/swift-commandlinekit/Tests/LinuxMain.swift
+++ b/External/swift-commandlinekit/Tests/LinuxMain.swift
@@ -1,0 +1,49 @@
+//
+//  LinuxMain.swift
+//  CommandLineKitTests
+//
+//  Created by Matthias Zenger on 02/06/2018.
+//  Copyright © 2018-2019 Google LLC
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//  * Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+//  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#if os(Linux)
+
+import XCTest
+@testable import CommandLineKitTests
+
+XCTMain(
+  [
+    testCase(FlagTests.allTests),
+    testCase(LineReaderHistoryTests.allTests),
+    testCase(EditStateTests.allTests),
+    testCase(AnsiCodesTests.allTests),
+  ]
+)
+
+#endif
+

--- a/External/swift-syntax/CodeGeneration/Package.swift
+++ b/External/swift-syntax/CodeGeneration/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     .executable(name: "generate-swift-syntax", targets: ["generate-swift-syntax"])
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax", from: "510.0.0"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+    .package(path: ".."),
+    .package(path: "../../swift-argument-parser"),
   ],
   targets: [
     .executableTarget(

--- a/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step3.swift
+++ b/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step3.swift
@@ -14,7 +14,7 @@ let package = Package(
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main")
+    .package(path: "../swift-syntax")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step4.swift
+++ b/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step4.swift
@@ -14,7 +14,7 @@ let package = Package(
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main")
+    .package(path: "../swift-syntax")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step5.swift
+++ b/External/swift-syntax/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step5.swift
@@ -17,7 +17,7 @@ let package = Package(
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main")
+    .package(path: "../swift-syntax")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/External/swift-syntax/SwiftParserCLI/Package.swift
+++ b/External/swift-syntax/SwiftParserCLI/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     .executable(name: "swift-parser-cli", targets: ["swift-parser-cli"])
   ],
   dependencies: [
-    .package(path: "..")
+    .package(path: ".."),
+    .package(path: "../../swift-argument-parser"),
   ],
   targets: [
     .target(
@@ -34,14 +35,3 @@ let package = Package(
     ),
   ]
 )
-
-if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
-  // Building standalone.
-  package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
-  ]
-} else {
-  package.dependencies += [
-    .package(path: "../../swift-argument-parser")
-  ]
-}

--- a/External/swift-syntax/SwiftSyntaxDevUtils/Package.swift
+++ b/External/swift-syntax/SwiftSyntaxDevUtils/Package.swift
@@ -20,14 +20,6 @@ let package = Package(
     )
   ]
 )
-
-if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
-  // Building standalone.
-  package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
-  ]
-} else {
-  package.dependencies += [
-    .package(path: "../../swift-argument-parser")
-  ]
-}
+package.dependencies += [
+  .package(path: "../../swift-argument-parser")
+]

--- a/external_packages.json
+++ b/external_packages.json
@@ -740,6 +740,21 @@
       ]
     },
     {
+      "name": "swift-commandlinekit",
+      "currentVersion": "0.2.5",
+      "spmSupported": true,
+      "targetVersion": "0.2.5",
+      "git": "https://github.com/objecthub/swift-commandlinekit",
+      "products": [
+        "CommandLineKit"
+      ],
+      "xcframeworks": [],
+      "packageName": "CommandLineKit",
+      "exports": [
+        "CommandLineKit"
+      ]
+    },
+    {
       "name": "swift-argument-parser",
       "currentVersion": "1.2.3",
       "spmSupported": true,


### PR DESCRIPTION
## Summary
- remove remote package references in vendored manifests so dependencies resolve locally
- add locally vendored CommandLineKit and track it in external_packages.json
- update swift-syntax and Firebase tooling manifests to use local packages instead of remote URLs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d9fa1ea8832e94f94ee4c4dd8f85)